### PR TITLE
refactor: extract API calls to the Optscale API, Optscale Auth API and the API Modifier into separate clients

### DIFF
--- a/app/api_clients/__init__.py
+++ b/app/api_clients/__init__.py
@@ -1,0 +1,8 @@
+from app.api_clients.api_modifier import *  # noqa: F401, F403
+from app.api_clients.base import BaseAPIClient  # noqa: F401
+from app.api_clients.optscale import *  # noqa: F401, F403
+from app.api_clients.optscale_auth import *  # noqa: F401, F403
+
+# NOTE: We're importing all the client classes both for convenience (easier imports),
+#       and also so that the __init_subclass__ method in BaseAPIClient is called for
+#       each client (needed for automatically setting up their svcs services)

--- a/app/api_clients/api_modifier.py
+++ b/app/api_clients/api_modifier.py
@@ -1,8 +1,4 @@
-from collections.abc import AsyncGenerator
-from typing import Annotated
-
 import httpx
-from fastapi import Depends
 
 from app import settings
 from app.api_clients.base import APIClientError, BaseAPIClient, BearerAuth
@@ -10,7 +6,7 @@ from app.utils import get_api_modifier_jwt_token
 
 
 class APIModifierClientError(APIClientError):
-    client_name = "APIModifier"
+    pass
 
 
 class APIModifierClient(BaseAPIClient):
@@ -48,11 +44,3 @@ class APIModifierClient(BaseAPIClient):
         )
         response.raise_for_status()
         return response
-
-
-async def get_api_modifier_client() -> AsyncGenerator[APIModifierClient]:
-    async with APIModifierClient() as client:
-        yield client
-
-
-APIModifier = Annotated[APIModifierClient, Depends(get_api_modifier_client)]

--- a/app/api_clients/api_modifier.py
+++ b/app/api_clients/api_modifier.py
@@ -5,7 +5,7 @@ import httpx
 from fastapi import Depends
 
 from app import settings
-from app.api_clients.base import APIClientError, BaseAPIClient, HeaderAuth
+from app.api_clients.base import APIClientError, BaseAPIClient, BearerAuth
 from app.utils import get_api_modifier_jwt_token
 
 
@@ -15,7 +15,9 @@ class APIModifierClientError(APIClientError):
 
 class APIModifierClient(BaseAPIClient):
     base_url = settings.api_modifier_base_url
-    auth = HeaderAuth("Authorization", lambda: f"Bearer {get_api_modifier_jwt_token()}")
+
+    def get_auth(self) -> BearerAuth:
+        return BearerAuth(get_api_modifier_jwt_token())
 
     async def create_user(self, email: str, display_name: str, password: str) -> httpx.Response:
         response = await self.httpx_client.post(

--- a/app/api_clients/base.py
+++ b/app/api_clients/base.py
@@ -1,0 +1,121 @@
+import abc
+import json
+import logging
+from collections.abc import Callable, Generator
+from types import TracebackType
+from typing import ClassVar, Self
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class HeaderAuth(httpx.Auth):
+    def __init__(self, header_name: str, header_value: str | Callable[[], str]):
+        self.header_name = header_name
+        self.get_header_value = header_value if callable(header_value) else lambda: header_value
+
+    def auth_flow(self, request: httpx.Request) -> Generator[httpx.Request, httpx.Response, None]:
+        if self.header_name not in request.headers:
+            request.headers[self.header_name] = self.get_header_value()
+
+        yield request
+
+
+class APIClientError(Exception):
+    client_name: ClassVar[str]
+    _clients_by_name: ClassVar[dict[str, type["APIClientError"]]] = {}
+
+    def __init_subclass__(cls):
+        cls._clients_by_name[cls.client_name] = cls
+
+    @classmethod
+    def for_client(cls, client_name: str) -> type["APIClientError"]:
+        return cls._clients_by_name.get(client_name, cls)
+
+    def __init__(self, message: str):
+        self.message = message
+
+        super().__init__(f"{self.client_name} API client error: {message}")
+
+
+class BaseAPIClient(abc.ABC):
+    base_url: ClassVar[str]
+    auth: ClassVar[httpx.Auth | None] = None
+
+    def __init__(self):
+        self.httpx_client = httpx.AsyncClient(
+            base_url=self.base_url,
+            auth=self.auth,
+            event_hooks={"request": [self._log_request], "response": [self._log_response]},
+        )
+
+    async def __aenter__(self) -> Self:
+        await self.httpx_client.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_val: BaseException | None = None,
+        exc_tb: TracebackType | None = None,
+    ) -> None:
+        return await self.httpx_client.__aexit__(exc_type, exc_val, exc_tb)
+
+    def _get_headers_to_log(self, headers: httpx.Headers) -> dict[str, str]:
+        return {
+            key: value
+            for key, value in headers.items()
+            if not (
+                isinstance(self.auth, HeaderAuth) and key.lower() == self.auth.header_name.lower()
+            )
+        }
+
+    async def _log_request(self, request: httpx.Request) -> None:
+        structured_log_data = {
+            "method": request.method,
+            "host": request.url.host,
+            "port": request.url.port,
+            "path": request.url.raw_path,
+            "headers": self._get_headers_to_log(request.headers),
+            "params": request.url.params,
+        }
+
+        try:
+            structured_log_data["json"] = json.loads(request.content)
+        except json.JSONDecodeError:
+            structured_log_data["content"] = request.content
+
+        logger.info(
+            "Request event hook: %s %s - Waiting for response",
+            request.method,
+            request.url,
+            extra=structured_log_data,
+        )
+
+    async def _log_response(self, response: httpx.Response) -> None:
+        request = response.request
+
+        structured_log_data = {
+            "method": request.method,
+            "host": request.url.host,
+            "port": request.url.port,
+            "path": request.url.raw_path,
+            "headers": self._get_headers_to_log(response.headers),
+            "status_code": response.status_code,
+            "is_error": response.is_error,
+        }
+
+        await response.aread()
+        try:
+            structured_log_data["json"] = response.json()
+        except json.JSONDecodeError:
+            structured_log_data["content"] = response.content
+
+        logger.info(
+            "Response event hook: %s %s - Status %s",
+            request.method,
+            request.url,
+            response.status_code,
+            extra=structured_log_data,
+        )

--- a/app/api_clients/optscale.py
+++ b/app/api_clients/optscale.py
@@ -1,15 +1,11 @@
-from collections.abc import AsyncGenerator
-from typing import Annotated
-
 import httpx
-from fastapi import Depends
 
 from app import settings
 from app.api_clients.base import APIClientError, BaseAPIClient
 
 
 class OptscaleClientError(APIClientError):
-    client_name = "Optscale"
+    pass
 
 
 class OptscaleClient(BaseAPIClient):
@@ -23,11 +19,3 @@ class OptscaleClient(BaseAPIClient):
 
         response.raise_for_status()
         return response
-
-
-async def get_optscale_client() -> AsyncGenerator[OptscaleClient]:
-    async with OptscaleClient() as client:
-        yield client
-
-
-Optscale = Annotated[OptscaleClient, Depends(get_optscale_client)]

--- a/app/api_clients/optscale.py
+++ b/app/api_clients/optscale.py
@@ -1,0 +1,33 @@
+from collections.abc import AsyncGenerator
+from typing import Annotated
+
+import httpx
+from fastapi import Depends
+
+from app import settings
+from app.api_clients.base import APIClientError, BaseAPIClient
+
+
+class OptscaleClientError(APIClientError):
+    client_name = "Optscale"
+
+
+class OptscaleClient(BaseAPIClient):
+    base_url = settings.opt_api_base_url
+
+    async def reset_password(self, email: str) -> httpx.Response:
+        response = await self.httpx_client.post(
+            "/restore_password",
+            json={"email": email},
+        )
+
+        response.raise_for_status()
+        return response
+
+
+async def get_optscale_client() -> AsyncGenerator[OptscaleClient]:
+    async with OptscaleClient() as client:
+        yield client
+
+
+Optscale = Annotated[OptscaleClient, Depends(get_optscale_client)]

--- a/app/api_clients/optscale_auth.py
+++ b/app/api_clients/optscale_auth.py
@@ -1,15 +1,11 @@
-from collections.abc import AsyncGenerator
-from typing import Annotated
-
 import httpx
-from fastapi import Depends
 
 from app import settings
 from app.api_clients.base import APIClientError, BaseAPIClient, HeaderAuth
 
 
 class OptscaleAuthClientError(APIClientError):
-    client_name = "OptscaleAuth"
+    pass
 
 
 class UserDoesNotExist(OptscaleAuthClientError):
@@ -37,11 +33,3 @@ class OptscaleAuthClient(BaseAPIClient):
             raise UserDoesNotExist(email)
 
         return response
-
-
-async def get_optscale_auth_client() -> AsyncGenerator[OptscaleAuthClient]:
-    async with OptscaleAuthClient() as client:
-        yield client
-
-
-OptscaleAuth = Annotated[OptscaleAuthClient, Depends(get_optscale_auth_client)]

--- a/app/api_clients/optscale_auth.py
+++ b/app/api_clients/optscale_auth.py
@@ -1,0 +1,47 @@
+from collections.abc import AsyncGenerator
+from typing import Annotated
+
+import httpx
+from fastapi import Depends
+
+from app import settings
+from app.api_clients.base import APIClientError, BaseAPIClient, HeaderAuth
+
+
+class OptscaleAuthClientError(APIClientError):
+    client_name = "OptscaleAuth"
+
+
+class UserDoesNotExist(OptscaleAuthClientError):
+    def __init__(self, email: str):
+        self.email = email
+        super().__init__(f"User with email {email} does not exist")
+
+
+class OptscaleAuthClient(BaseAPIClient):
+    base_url = settings.opt_auth_base_url
+    auth = HeaderAuth("Secret", settings.opt_cluster_secret)
+
+    async def get_existing_user_info(self, email: str) -> httpx.Response:
+        response = await self.httpx_client.get(
+            "/user_existence",
+            params={
+                "email": email,
+                "user_info": "true",
+            },
+        )
+        response.raise_for_status()
+        response_data = response.json()
+
+        if not response_data.get("exists", False):
+            raise UserDoesNotExist(email)
+
+        return response
+
+
+async def get_optscale_auth_client() -> AsyncGenerator[OptscaleAuthClient]:
+    async with OptscaleAuthClient() as client:
+        yield client
+
+
+OptscaleAuth = Annotated[OptscaleAuthClient, Depends(get_optscale_auth_client)]

--- a/app/main.py
+++ b/app/main.py
@@ -1,19 +1,27 @@
 import logging
-from contextlib import asynccontextmanager
 
 import fastapi_pagination
+import svcs
 from fastapi import FastAPI
 
 from app import settings
+from app.api_clients import BaseAPIClient
 from app.db import verify_db_connection
 from app.routers import entitlements, organizations, users
 
 logger = logging.getLogger(__name__)
 
 
-@asynccontextmanager
-async def lifespan(app: FastAPI):
+@svcs.fastapi.lifespan
+async def lifespan(app: FastAPI, registry: svcs.Registry):
+    # TODO: Move the database setup to a svcs service and
+    #       use the function bellow its healthcheck
     await verify_db_connection()
+
+    for client_name, client_cls in BaseAPIClient.get_clients_by_name().items():
+        logging.info("Registering %s API client as a service", client_name)
+        registry.register_factory(svc_type=client_cls, factory=client_cls)
+
     yield
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -12,15 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI):  # pragma: no cover
-    # NOTE: the lifespan is not executed when running the tests (thus the pragma: no cover)
-    #       There is a way to change that with florimondmanca/asgi-lifespan but it's not
-    #       needed for now as the lifespan is only used to verify the DB connection.
-    #
-    # refs:
-    #     * https://fastapi.tiangolo.com/advanced/async-tests/#run-it
-    #     * https://github.com/florimondmanca/asgi-lifespan#usage
-
+async def lifespan(app: FastAPI):
     await verify_db_connection()
     yield
 

--- a/app/routers/organizations.py
+++ b/app/routers/organizations.py
@@ -1,9 +1,10 @@
 from uuid import UUID
 
+import svcs
 from fastapi import APIRouter, HTTPException, status
 from fastapi_pagination.limit_offset import LimitOffsetPage
 
-from app.api_clients.api_modifier import APIModifier
+from app.api_clients import APIModifierClient
 from app.auth import CurrentSystem
 from app.db.handlers import ConstraintViolationError, NotFoundError
 from app.db.models import Organization
@@ -27,8 +28,10 @@ async def create_organization(
     data: OrganizationCreate,
     organization_repo: OrganizationRepository,
     current_system: CurrentSystem,
-    api_modifier_client: APIModifier,
+    services: svcs.fastapi.DepContainer,
 ):
+    api_modifier_client = await services.aget(APIModifierClient)
+
     db_organization: Organization | None = None
     try:
         organization = to_orm(data, Organization)

--- a/app/routers/organizations.py
+++ b/app/routers/organizations.py
@@ -1,17 +1,16 @@
 from uuid import UUID
 
-import httpx
 from fastapi import APIRouter, HTTPException, status
 from fastapi_pagination.limit_offset import LimitOffsetPage
 
-from app import settings
+from app.api_clients.api_modifier import APIModifier
 from app.auth import CurrentSystem
 from app.db.handlers import ConstraintViolationError, NotFoundError
 from app.db.models import Organization
 from app.pagination import paginate
 from app.repositories import OrganizationRepository
 from app.schemas import OrganizationCreate, OrganizationRead, from_orm, to_orm
-from app.utils import get_api_modifier_jwt_token
+from app.utils import wrap_http_error_in_502
 
 router = APIRouter()
 
@@ -28,6 +27,7 @@ async def create_organization(
     data: OrganizationCreate,
     organization_repo: OrganizationRepository,
     current_system: CurrentSystem,
+    api_modifier_client: APIModifier,
 ):
     db_organization: Organization | None = None
     try:
@@ -41,34 +41,19 @@ async def create_organization(
             detail=f"Organization with this external ID already exists: {data.external_id}.",
         )
 
-    try:
-        async with httpx.AsyncClient(base_url=settings.api_modifier_base_url) as client:
-            response = await client.post(
-                "/admin/organizations",
-                headers={"Authorization": f"Bearer {get_api_modifier_jwt_token()}"},
-                json={
-                    "org_name": data.name,
-                    "user_id": data.user_id,
-                    "currency": data.currency,
-                },
-            )
-            response.raise_for_status()
-            ffc_organization = response.json()
-            db_organization = await organization_repo.update(
-                db_organization.id,
-                {
-                    "organization_id": ffc_organization["id"],
-                },
-            )
-            return from_orm(OrganizationRead, db_organization)
-    except httpx.HTTPStatusError as e:
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=(
-                "Error creating organization in FinOps for Cloud: "
-                f"{e.response.status_code} - {e.response.text}.",
-            ),
-        ) from e
+    async with wrap_http_error_in_502("Error creating organization in FinOps for Cloud"):
+        response = await api_modifier_client.create_organization(
+            org_name=data.name, user_id=data.user_id, currency=data.currency
+        )
+
+        ffc_organization = response.json()
+        db_organization = await organization_repo.update(
+            db_organization.id,
+            {
+                "organization_id": ffc_organization["id"],
+            },
+        )
+        return from_orm(OrganizationRead, db_organization)
 
 
 @router.get("/{id}", response_model=OrganizationRead)

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -1,70 +1,40 @@
 import secrets
 
-import httpx
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, status
 
-from app import settings
+from app.api_clients.api_modifier import APIModifier
+from app.api_clients.optscale import Optscale
+from app.api_clients.optscale_auth import OptscaleAuth, UserDoesNotExist
 from app.auth import CurrentSystem
 from app.schemas import UserCreate, UserRead
-from app.utils import get_api_modifier_jwt_token
+from app.utils import wrap_http_error_in_502
 
 router = APIRouter()
 
 
 @router.post("/", response_model=UserRead, status_code=status.HTTP_201_CREATED)
-async def create_user(data: UserCreate, system: CurrentSystem):
-    try:
-        async with httpx.AsyncClient(base_url=settings.opt_auth_base_url) as client:
-            response = await client.get(
-                "/user_existence",
-                headers={"Secret": settings.opt_cluster_secret},
-                params={
-                    "email": data.email,
-                    "user_info": "true",
-                },
-            )
-            response.raise_for_status()
-            exist_user_response = response.json()
-            if exist_user_response["exists"]:
-                return UserRead(**exist_user_response["user_info"])
-    except httpx.HTTPStatusError as e:
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=(
-                "Error checking user existence in FinOps for Cloud: "
-                f"{e.response.status_code} - {e.response.text}.",
-            ),
-        ) from e
+async def create_user(
+    data: UserCreate,
+    system: CurrentSystem,
+    optscale_auth_client: OptscaleAuth,
+    api_modifier_client: APIModifier,
+    optscale_client: Optscale,
+):
+    async with wrap_http_error_in_502("Error checking user existence in FinOps for Cloud"):
+        try:
+            response = await optscale_auth_client.get_existing_user_info(data.email)
+        except UserDoesNotExist:
+            pass
+        else:
+            return UserRead(**response.json()["user_info"])
 
-    try:
-        async with httpx.AsyncClient(base_url=settings.api_modifier_base_url) as client:
-            response = await client.post(
-                "/admin/users",
-                headers={"Authorization": f"Bearer {get_api_modifier_jwt_token()}"},
-                json={
-                    "email": data.email,
-                    "display_name": data.display_name,
-                    "password": secrets.token_urlsafe(128),
-                },
-            )
-            response.raise_for_status()
-            create_user_response = response.json()
+    async with wrap_http_error_in_502("Error creating user in FinOps for Cloud"):
+        create_user_response = await api_modifier_client.create_user(
+            email=data.email,
+            display_name=data.display_name,
+            password=secrets.token_urlsafe(128),
+        )
 
-        async with httpx.AsyncClient(base_url=settings.opt_api_base_url) as client:
-            response = await client.post(
-                "/restore_password",
-                json={
-                    "email": data.email,
-                },
-            )
-            response.raise_for_status()
+        await optscale_client.reset_password(data.email)
 
-        return UserRead(**create_user_response)
-    except httpx.HTTPStatusError as e:
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=(
-                "Error creating user in FinOps for Cloud: "
-                f"{e.response.status_code} - {e.response.text}.",
-            ),
-        ) from e
+        return UserRead(**create_user_response.json())

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,6 +1,9 @@
+import contextlib
 from datetime import UTC, datetime, timedelta
 
+import httpx
 import jwt
+from fastapi import HTTPException, status
 
 from app import settings
 from app.constants import (
@@ -26,3 +29,14 @@ def get_api_modifier_jwt_token() -> str:
         settings.api_modifier_jwt_secret,
         algorithm=API_MODIFIER_JWT_ALGORITHM,
     )
+
+
+@contextlib.asynccontextmanager
+async def wrap_http_error_in_502(base_msg: str = "Error in FinOps for Cloud"):
+    try:
+        yield
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"{base_msg}: {e.response.status_code} - {e.response.text}.",
+        ) from e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "gunicorn==23.0.*",
     "uvloop==0.21.*",
     "uvicorn-worker==0.3.*",
+    "svcs>=24.1.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "pytest-mock>=3.14.0",
     "freezegun>=1.5.1,<2.0",
     "ipdb>=0.13.13",
+    "asgi-lifespan>=2.1.0",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "gunicorn==23.0.*",
     "uvloop==0.21.*",
     "uvicorn-worker==0.3.*",
-    "svcs>=24.1.0",
+    "svcs==24.1.*",
 ]
 
 [dependency-groups]
@@ -42,7 +42,7 @@ dev = [
     "pytest-mock>=3.14.0",
     "freezegun>=1.5.1,<2.0",
     "ipdb>=0.13.13",
-    "asgi-lifespan>=2.1.0",
+    "asgi-lifespan>=2.1.0,<3.0",
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,9 @@ from collections.abc import AsyncGenerator, Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from typing import TypeVar
 
-import fastapi_pagination
 import jwt
 import pytest
+from asgi_lifespan import LifespanManager
 from faker import Faker
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
@@ -38,11 +38,11 @@ def mock_settings() -> None:
 
 
 @pytest.fixture(scope="session", autouse=True)
-def fastapi_app(mock_settings) -> FastAPI:
+async def fastapi_app(mock_settings) -> FastAPI:
     from app.main import app
 
-    fastapi_pagination.add_pagination(app)
-    return app
+    async with LifespanManager(app) as lifespan_manager:
+        yield lifespan_manager.app
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,6 @@ from app import settings
 from app.db import db_engine
 from app.db.models import Actor, Base, Entitlement, Organization, System
 from app.enums import ActorType
-from app.main import app
 
 ModelT = TypeVar("ModelT", bound=Base)
 ModelFactory = Callable[..., Awaitable[ModelT]]
@@ -29,8 +28,19 @@ def pytest_collection_modifyitems(items):
         async_test.add_marker(session_scope_marker, append=False)
 
 
+@pytest.fixture(scope="session")
+def mock_settings() -> None:
+    settings.opt_cluster_secret = "test_cluster_secret"
+    settings.opt_api_base_url = "https://opt-api.ffc.com"
+    settings.opt_auth_base_url = "https://opt-auth.ffc.com"
+    settings.api_modifier_base_url = "https://api-modifier.ffc.com"
+    settings.api_modifier_jwt_secret = "test_jwt_secret"
+
+
 @pytest.fixture(scope="session", autouse=True)
-def fastapi_app() -> FastAPI:
+def fastapi_app(mock_settings) -> FastAPI:
+    from app.main import app
+
     fastapi_pagination.add_pagination(app)
     return app
 
@@ -115,15 +125,6 @@ def organization_factory(faker: Faker, db_session: AsyncSession) -> ModelFactory
         return organization
 
     return _organization
-
-
-@pytest.fixture(scope="session", autouse=True)
-def mock_settings() -> None:
-    settings.opt_cluster_secret = "test_cluster_secret"
-    settings.opt_api_base_url = "https://opt-api.ffc.com"
-    settings.opt_auth_base_url = "https://opt-auth.ffc.com"
-    settings.api_modifier_base_url = "https://api-modifier.ffc.com"
-    settings.api_modifier_jwt_secret = "test_jwt_secret"
 
 
 @pytest.fixture

--- a/tests/test_organizations_api.py
+++ b/tests/test_organizations_api.py
@@ -114,7 +114,9 @@ async def test_can_create_organizations(
     db_session: AsyncSession,
     gcp_jwt_token: str,
 ):
-    mocker.patch("app.routers.organizations.get_api_modifier_jwt_token", return_value="test_token")
+    mocker.patch(
+        "app.api_clients.api_modifier.get_api_modifier_jwt_token", return_value="test_token"
+    )
 
     httpx_mock.add_response(
         method="POST",
@@ -203,7 +205,9 @@ async def test_create_organization_api_modifier_error(
     api_client: AsyncClient,
     gcp_jwt_token: str,
 ):
-    mocker.patch("app.routers.organizations.get_api_modifier_jwt_token", return_value="test_token")
+    mocker.patch(
+        "app.api_clients.api_modifier.get_api_modifier_jwt_token", return_value="test_token"
+    )
 
     httpx_mock.add_response(
         method="POST",
@@ -225,7 +229,7 @@ async def test_create_organization_api_modifier_error(
 
     assert response.status_code == 502
 
-    [detail] = response.json()["detail"]
+    detail = response.json()["detail"]
     assert detail == "Error creating organization in FinOps for Cloud: 500 - Internal Server Error."
 
 

--- a/tests/test_users_api.py
+++ b/tests/test_users_api.py
@@ -11,7 +11,9 @@ async def test_can_create_users(
     api_client: AsyncClient,
     ffc_jwt_token: str,
 ):
-    mocker.patch("app.routers.users.get_api_modifier_jwt_token", return_value="test_token")
+    mocker.patch(
+        "app.api_clients.api_modifier.get_api_modifier_jwt_token", return_value="test_token"
+    )
     mocked_token_urlsafe = mocker.patch(
         "app.routers.users.secrets.token_urlsafe", return_value="random_password"
     )
@@ -69,7 +71,9 @@ async def test_create_user_already_exists(
     api_client: AsyncClient,
     ffc_jwt_token: str,
 ):
-    mocker.patch("app.routers.users.get_api_modifier_jwt_token", return_value="test_token")
+    mocker.patch(
+        "app.api_clients.api_modifier.get_api_modifier_jwt_token", return_value="test_token"
+    )
 
     httpx_mock.add_response(
         method="GET",
@@ -105,7 +109,9 @@ async def test_create_user_check_existence_error(
     api_client: AsyncClient,
     ffc_jwt_token: str,
 ):
-    mocker.patch("app.routers.users.get_api_modifier_jwt_token", return_value="test_token")
+    mocker.patch(
+        "app.api_clients.api_modifier.get_api_modifier_jwt_token", return_value="test_token"
+    )
 
     httpx_mock.add_response(
         method="GET",
@@ -122,9 +128,7 @@ async def test_create_user_check_existence_error(
     )
     assert response.status_code == 502
     assert response.json() == {
-        "detail": [
-            "Error checking user existence in FinOps for Cloud: 500 - Internal Server Error.",
-        ],
+        "detail": "Error checking user existence in FinOps for Cloud: 500 - Internal Server Error.",
     }
 
 
@@ -134,7 +138,9 @@ async def test_create_user_error_creating_user(
     api_client: AsyncClient,
     ffc_jwt_token: str,
 ):
-    mocker.patch("app.routers.users.get_api_modifier_jwt_token", return_value="test_token")
+    mocker.patch(
+        "app.api_clients.api_modifier.get_api_modifier_jwt_token", return_value="test_token"
+    )
 
     httpx_mock.add_response(
         method="GET",
@@ -156,7 +162,5 @@ async def test_create_user_error_creating_user(
     )
     assert response.status_code == 502
     assert response.json() == {
-        "detail": [
-            "Error creating user in FinOps for Cloud: 500 - Internal Server Error.",
-        ],
+        "detail": "Error creating user in FinOps for Cloud: 500 - Internal Server Error.",
     }

--- a/uv.lock
+++ b/uv.lock
@@ -87,6 +87,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "24.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/c8/6260f8ccc11f0917360fc0da435c5c9c7504e3db174d5a12a1494887b045/attrs-24.3.0.tar.gz", hash = "sha256:8f5c07333d543103541ba7be0e2ce16eeee8130cb0b3f9238ab904ce1e85baff", size = 805984 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/aa/ab0f7891a01eeb2d2e338ae8fecbe57fcebea1a24dbb64d45801bfab481d/attrs-24.3.0-py3-none-any.whl", hash = "sha256:ac96cd038792094f438ad1f6ff80837353805ac950cd2aa0e0625ef19850c308", size = 63397 },
+]
+
+[[package]]
 name = "bandit"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -670,6 +679,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "sqlalchemy-utils" },
+    { name = "svcs" },
     { name = "uvicorn-worker" },
     { name = "uvloop" },
 ]
@@ -707,6 +717,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = "==1.0.*" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = "==2.0.*" },
     { name = "sqlalchemy-utils", specifier = "==0.41.*" },
+    { name = "svcs", specifier = ">=24.1.0" },
     { name = "uvicorn-worker", specifier = "==0.3.*" },
     { name = "uvloop", specifier = "==0.21.*" },
 ]
@@ -1243,6 +1254,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4a/e9/4eedccff8332cc40cc60ddd3b28d4c3e255ee7e9c65679fa4533ab98f598/stevedore-5.4.0.tar.gz", hash = "sha256:79e92235ecb828fe952b6b8b0c6c87863248631922c8e8e0fa5b17b232c4514d", size = 513899 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/73/d0091d22a65b55e8fb6aca7b3b6713b5a261dd01cec4cfd28ed127ac0cfc/stevedore-5.4.0-py3-none-any.whl", hash = "sha256:b0be3c4748b3ea7b854b265dcb4caa891015e442416422be16f8b31756107857", size = 49534 },
+]
+
+[[package]]
+name = "svcs"
+version = "24.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/35/d04e27a2c15dc948155eb4635338e9f2c66c5d0b68e1abee4eca887661f3/svcs-24.1.0.tar.gz", hash = "sha256:7419980475dd6b8e256e072c895c84cfe40d4da1ee944145f98724f2985dfd1f", size = 710520 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/75/795347abe56c4012fd511af35db80370f1461aa443546a83b32d65a19bbb/svcs-24.1.0-py3-none-any.whl", hash = "sha256:f050f4a6fcf163aa3a5d5e17b66bbf5efa3ed2164018aebecd70fc27794ecf6b", size = 18772 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -79,7 +79,7 @@ name = "bandit"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "stevedore" },
@@ -145,7 +145,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -686,7 +686,7 @@ requires-dist = [
     { name = "cryptography", specifier = "==44.0.*" },
     { name = "fastapi", extras = ["standard"], specifier = "==0.115.*" },
     { name = "fastapi-pagination", specifier = "==0.12.*" },
-    { name = "gunicorn", specifier = ">=23.0.0" },
+    { name = "gunicorn", specifier = "==23.0.*" },
     { name = "httpx", specifier = "==0.27.*" },
     { name = "pydantic-extra-types", specifier = "==2.10.*" },
     { name = "pydantic-settings", specifier = "==2.6.*" },
@@ -694,8 +694,8 @@ requires-dist = [
     { name = "python-dotenv", specifier = "==1.0.*" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = "==2.0.*" },
     { name = "sqlalchemy-utils", specifier = "==0.41.*" },
-    { name = "uvicorn-worker", specifier = ">=0.3.0" },
-    { name = "uvloop", specifier = ">=0.21.0" },
+    { name = "uvicorn-worker", specifier = "==0.3.*" },
+    { name = "uvloop", specifier = "==0.21.*" },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -717,14 +717,14 @@ requires-dist = [
     { name = "python-dotenv", specifier = "==1.0.*" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = "==2.0.*" },
     { name = "sqlalchemy-utils", specifier = "==0.41.*" },
-    { name = "svcs", specifier = ">=24.1.0" },
+    { name = "svcs", specifier = "==24.1.*" },
     { name = "uvicorn-worker", specifier = "==0.3.*" },
     { name = "uvloop", specifier = "==0.21.*" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "asgi-lifespan", specifier = ">=2.1.0" },
+    { name = "asgi-lifespan", specifier = ">=2.1.0,<3.0" },
     { name = "bandit", specifier = ">=1.8.0,<2.0" },
     { name = "faker", specifier = ">=33.1.0,<34.0" },
     { name = "freezegun", specifier = ">=1.5.1,<2.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -42,6 +42,18 @@ wheels = [
 ]
 
 [[package]]
+name = "asgi-lifespan"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sniffio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/da/e7908b54e0f8043725a990bf625f2041ecf6bfe8eb7b19407f1c00b630f7/asgi-lifespan-2.1.0.tar.gz", hash = "sha256:5e2effaf0bfe39829cf2d64e7ecc47c7d86d676a6599f7afba378c31f5e3a308", size = 15627 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/f5/c36551e93acba41a59939ae6a0fb77ddb3f2e8e8caa716410c65f7341f72/asgi_lifespan-2.1.0-py3-none-any.whl", hash = "sha256:ed840706680e28428c01e14afb3875d7d76d3206f3d5b2f2294e059b5c23804f", size = 10895 },
+]
+
+[[package]]
 name = "asttokens"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -664,6 +676,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "asgi-lifespan" },
     { name = "bandit" },
     { name = "faker" },
     { name = "freezegun" },
@@ -700,6 +713,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "asgi-lifespan", specifier = ">=2.1.0" },
     { name = "bandit", specifier = ">=1.8.0,<2.0" },
     { name = "faker", specifier = ">=33.1.0,<34.0" },
     { name = "freezegun", specifier = ">=1.5.1,<2.0" },


### PR DESCRIPTION
Please let me know what you think of this design. I intentionally kept the test changes as minimal as possible to hear your thoughts on the approach before committing more time. However, with the current design, the tests can be simplified a lot and we can easily create reusable mock objects with whatever information we need.

Feel free to review commit by commit as there are two other changes I bundled here, again let me know about your thoughts on these:

1. 65caa3acfcbc74f023f3c20798f585833c6855f0 -- allows for the fastapi lifespan to be executed when using the async testing client
2.  acbd949892e4d28ad61757f9b2a8395b5ab6e981 -- integrates the [`svcs`](https://svcs.hynek.me/en/stable/index.html) package for managing the clients and reduces boilerplate for creating dependancies for them. I think it can be used for many other things but I'm open to your thoughts as I haven't used it before. I found [this video](https://www.youtube.com/watch?v=d1elMD9WgpA) by the author to give a great explanation about the package's architecture and the problems it's solving