### PR TITLE
feat: Improve system endpoints payloads (MPT-7106)

### DIFF
--- a/app/auth/auth.py
+++ b/app/auth/auth.py
@@ -125,7 +125,7 @@ async def get_authentication_context(
         auth_context.reset(reset_token)
 
 
-async def check_operations_account(
+def check_operations_account(
     context: Annotated[AuthenticationContext, Depends(get_authentication_context)],
 ):
     """

--- a/app/hasher.py
+++ b/app/hasher.py
@@ -26,7 +26,7 @@ class PBKDF2Sha256PasswordHasher:
             raise ValueError("Password and hashed value cannot be empty.")
 
         try:
-            algorithm, iterations, salt_encoded, hash_encoded = hashed_value.split("$", 3)
+            _algorithm, iterations, salt_encoded, hash_encoded = hashed_value.split("$", 3)
             iterations = int(iterations)  # type: ignore
             salt = base64.b64decode(salt_encoded)
             expected_hash = base64.b64decode(hash_encoded)

--- a/app/routers/accounts.py
+++ b/app/routers/accounts.py
@@ -191,7 +191,7 @@ async def update_account(
         - HTTPException with status 403 if the check (1) fails
         - HTTPException with status 400 if the checks (2), (4) or (3) fail.
     """
-    await validate_required_conditions_before_update(account=account)
+    validate_required_conditions_before_update(account=account)
     return await update_data_and_format_response(
         id=account.id, account_repo=account_repo, data=data
     )

--- a/app/routers/accounts.py
+++ b/app/routers/accounts.py
@@ -64,7 +64,7 @@ async def update_data_and_format_response(
     return from_orm(AccountRead, db_account)
 
 
-async def validate_required_conditions_before_update(account: Account):
+def validate_required_conditions_before_update(account: Account):
     """
     This function performs the following required checks before
     proceeding to update an Account:

--- a/app/routers/employees.py
+++ b/app/routers/employees.py
@@ -16,16 +16,14 @@ async def create_employee(
     api_modifier_client: APIModifierClient,
     optscale_client: OptscaleClient,
 ):
-    async with wrap_http_error_in_502("Error creating employee in FinOps for Cloud"):
+    with wrap_http_error_in_502("Error creating employee in FinOps for Cloud"):
         create_employee_response = await api_modifier_client.create_user(
             email=data.email,
             display_name=data.display_name,
             password=secrets.token_urlsafe(128),
         )
 
-    async with wrap_http_error_in_502(
-        "Error resetting the password for employee in FinOps for Cloud"
-    ):
+    with wrap_http_error_in_502("Error resetting the password for employee in FinOps for Cloud"):
         await optscale_client.reset_password(data.email)
 
         return EmployeeRead(**create_employee_response.json())
@@ -36,7 +34,7 @@ async def get_employee_by_email(
     email: str,
     optscale_auth_client: OptscaleAuthClient,
 ):
-    async with wrap_http_error_in_502("Error checking employee existence in FinOps for Cloud"):
+    with wrap_http_error_in_502("Error checking employee existence in FinOps for Cloud"):
         try:
             response = await optscale_auth_client.get_existing_user_info(email)
         except UserDoesNotExist:

--- a/app/routers/entitlements.py
+++ b/app/routers/entitlements.py
@@ -21,7 +21,7 @@ from app.schemas import EntitlementCreate, EntitlementRead, EntitlementRedeem, f
 # ============
 
 
-async def common_extra_conditions(auth_ctx: CurrentAuthContext) -> list[ColumnExpressionArgument]:
+def common_extra_conditions(auth_ctx: CurrentAuthContext) -> list[ColumnExpressionArgument]:
     conditions: list[ColumnExpressionArgument] = []
 
     if auth_ctx.account.type == AccountType.AFFILIATE:

--- a/app/routers/organizations.py
+++ b/app/routers/organizations.py
@@ -57,7 +57,7 @@ async def create_organization(
                 ),
             )
 
-    async with wrap_http_error_in_502("Error creating organization in FinOps for Cloud"):
+    with wrap_http_error_in_502("Error creating organization in FinOps for Cloud"):
         response = await api_modifier_client.create_organization(
             org_name=db_organization.name, user_id=data.user_id, currency=data.currency
         )
@@ -105,9 +105,7 @@ async def get_datasources_by_organization_id(
             ),
         )
 
-    async with wrap_http_error_in_502(
-        f"Error fetching datasources for organization {organization.name}"
-    ):
+    with wrap_http_error_in_502(f"Error fetching datasources for organization {organization.name}"):
         response = await optscale_client.fetch_datasources_for_organization(
             organization_id=organization.operations_external_id
         )
@@ -142,7 +140,7 @@ async def get_datasource_by_id(
             ),
         )
 
-    async with wrap_http_error_in_502(f"Error fetching cloud account with ID {datasource_id}"):
+    with wrap_http_error_in_502(f"Error fetching cloud account with ID {datasource_id}"):
         response = await optscale_client.fetch_datasource_by_id(datasource_id)
 
     datasource = response.json()
@@ -171,9 +169,7 @@ async def get_employees_by_organization_id(
             ),
         )
 
-    async with wrap_http_error_in_502(
-        f"Error fetching employees for organization {organization.name}"
-    ):
+    with wrap_http_error_in_502(f"Error fetching employees for organization {organization.name}"):
         response = await optscale_client.fetch_users_for_organization(
             organization_id=organization.operations_external_id
         )
@@ -203,7 +199,7 @@ async def make_organization_user_admin(
     optscale_auth_client: OptscaleAuthClient,
     optscale_client: OptscaleClient,
 ):
-    async with wrap_http_error_in_502("Error making employee admin in FinOps for Cloud"):
+    with wrap_http_error_in_502("Error making employee admin in FinOps for Cloud"):
         # check user exists in optscale
         response = await optscale_client.fetch_user_by_id(str(user_id))
         user = response.json()

--- a/app/routers/systems.py
+++ b/app/routers/systems.py
@@ -9,7 +9,8 @@ from app.db.models import System
 from app.dependencies import AccountRepository, CurrentAuthContext, SystemId, SystemRepository
 from app.enums import AccountType, SystemStatus
 from app.pagination import paginate
-from app.schemas import SystemCreate, SystemRead, SystemUpdate, from_orm
+from app.schemas import SystemCreate, SystemCreateResponse, SystemRead, SystemUpdate, from_orm
+from app.utils import wrap_exc_in_http_response
 
 # ============
 # Dependencies
@@ -33,13 +34,8 @@ async def fetch_system_or_404(
     system_repo: SystemRepository,
     extra_conditions: CommonConditions,
 ) -> System:
-    try:
+    async with wrap_exc_in_http_response(NotFoundError, status_code=status.HTTP_404_NOT_FOUND):
         return await system_repo.get(id=id, extra_conditions=extra_conditions)
-    except NotFoundError as e:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=str(e),
-        ) from e
 
 
 # ======
@@ -63,28 +59,28 @@ async def get_systems(
     )
 
 
-@router.post("", response_model=SystemRead, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=SystemCreateResponse, status_code=status.HTTP_201_CREATED)
 async def create_system(
     data: SystemCreate,
     account_repo: AccountRepository,
     system_repo: SystemRepository,
     auth_ctx: CurrentAuthContext,
 ):
-    if auth_ctx.account.type == AccountType.AFFILIATE and data.owner.id != auth_ctx.account.id:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Affiliate users can only create systems bound to their own account.",
-        )
+    if data.owner is None:
+        system_owner = auth_ctx.account
+    else:
+        if auth_ctx.account.type == AccountType.AFFILIATE:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Affiliate users can only create systems bound to their own account.",
+            )
 
-    try:
-        system_owner = await account_repo.get(data.owner.id)
-    except NotFoundError as e:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="The owner account does not exist.",
-        ) from e
+        async with wrap_exc_in_http_response(NotFoundError, "The owner account does not exist."):
+            system_owner = await account_repo.get(data.owner.id)
 
-    try:
+    async with wrap_exc_in_http_response(
+        ConstraintViolationError, "A system with the same external ID already exists."
+    ):
         system = await system_repo.create(
             System(
                 name=data.name,
@@ -95,13 +91,8 @@ async def create_system(
                 status=SystemStatus.ACTIVE,
             )
         )
-    except ConstraintViolationError as e:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="A system with the same external ID already exists.",
-        ) from e
 
-    return from_orm(SystemRead, system)
+    return from_orm(SystemCreateResponse, system)
 
 
 @router.get("/{id}", response_model=SystemRead)
@@ -115,13 +106,10 @@ async def update_system(
     system_repo: SystemRepository,
     data: SystemUpdate,
 ):
-    try:
-        system = await system_repo.update(system, data.model_dump())
-    except ConstraintViolationError as e:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="A system with the same external ID already exists.",
-        ) from e
+    async with wrap_exc_in_http_response(
+        ConstraintViolationError, "A system with the same external ID already exists."
+    ):
+        system = await system_repo.update(system, data.model_dump(exclude_unset=True))
 
     return from_orm(SystemRead, system)
 

--- a/app/routers/systems.py
+++ b/app/routers/systems.py
@@ -17,7 +17,7 @@ from app.utils import wrap_exc_in_http_response
 # ============
 
 
-async def common_extra_conditions(auth_ctx: CurrentAuthContext) -> list[ColumnExpressionArgument]:
+def common_extra_conditions(auth_ctx: CurrentAuthContext) -> list[ColumnExpressionArgument]:
     conditions: list[ColumnExpressionArgument] = []
 
     if auth_ctx.account.type == AccountType.AFFILIATE:
@@ -34,7 +34,7 @@ async def fetch_system_or_404(
     system_repo: SystemRepository,
     extra_conditions: CommonConditions,
 ) -> System:
-    async with wrap_exc_in_http_response(NotFoundError, status_code=status.HTTP_404_NOT_FOUND):
+    with wrap_exc_in_http_response(NotFoundError, status_code=status.HTTP_404_NOT_FOUND):
         return await system_repo.get(id=id, extra_conditions=extra_conditions)
 
 
@@ -81,10 +81,10 @@ async def create_system(
                 detail="Affiliate users can only create systems bound to their own account.",
             )
 
-        async with wrap_exc_in_http_response(NotFoundError, "The owner account does not exist."):
+        with wrap_exc_in_http_response(NotFoundError, "The owner account does not exist."):
             system_owner = await account_repo.get(data.owner.id)
 
-    async with wrap_exc_in_http_response(
+    with wrap_exc_in_http_response(
         ConstraintViolationError, "A system with the same external ID already exists."
     ):
         system = await system_repo.create(
@@ -112,7 +112,7 @@ async def update_system(
     system_repo: SystemRepository,
     data: SystemUpdate,
 ):
-    async with wrap_exc_in_http_response(
+    with wrap_exc_in_http_response(
         ConstraintViolationError, "A system with the same external ID already exists."
     ):
         system = await system_repo.update(system, data.model_dump(exclude_unset=True))

--- a/app/routers/systems.py
+++ b/app/routers/systems.py
@@ -67,6 +67,12 @@ async def create_system(
     auth_ctx: CurrentAuthContext,
 ):
     if data.owner is None:
+        if auth_ctx.account.type == AccountType.OPERATIONS:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Operations users must specify an owner account when creating a system.",
+            )
+
         system_owner = auth_ctx.account
     else:
         if auth_ctx.account.type == AccountType.AFFILIATE:

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -144,6 +144,15 @@ class SystemBase(BaseSchema):
     ]
     external_id: Annotated[str, Field(max_length=255)]
     description: Annotated[str | None, Field(max_length=2000)] = None
+    owner: AccountReference
+
+
+class SystemRead(IdSchema, CommonEventsSchema, SystemBase):
+    status: SystemStatus
+
+
+class SystemCreate(SystemBase):
+    owner: IdSchema | None = None  # type: ignore[assignment]
     jwt_secret: Annotated[
         str | None,
         Field(
@@ -154,21 +163,17 @@ class SystemBase(BaseSchema):
             ],
         ),
     ] = None
-    owner: AccountReference
-
-
-class SystemCreate(SystemBase):
-    owner: IdSchema  # type: ignore
 
 
 class SystemUpdate(BaseSchema):
     name: str
     external_id: Annotated[str, Field(max_length=255)]
     description: Annotated[str | None, Field(max_length=2000)] = None
+    jwt_secret: Annotated[str | None, Field(min_length=64)] = None
 
 
-class SystemRead(IdSchema, CommonEventsSchema, SystemBase):
-    status: SystemStatus
+class SystemCreateResponse(SystemRead):
+    jwt_secret: str
 
 
 class UserBase(BaseSchema):

--- a/app/utils.py
+++ b/app/utils.py
@@ -7,8 +7,8 @@ from fastapi import HTTPException, status
 logger = logging.getLogger(__name__)
 
 
-@contextlib.asynccontextmanager
-async def wrap_http_error_in_502(base_msg: str = "Error in FinOps for Cloud"):
+@contextlib.contextmanager
+def wrap_http_error_in_502(base_msg: str = "Error in FinOps for Cloud"):
     try:
         yield
     except httpx.HTTPStatusError as e:
@@ -18,8 +18,8 @@ async def wrap_http_error_in_502(base_msg: str = "Error in FinOps for Cloud"):
         ) from e
 
 
-@contextlib.asynccontextmanager
-async def wrap_exc_in_http_response(
+@contextlib.contextmanager
+def wrap_exc_in_http_response(
     exc_cls: type[Exception],
     error_msg: str | None = None,
     status_code: int = status.HTTP_400_BAD_REQUEST,

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,7 +1,10 @@
 import contextlib
+import logging
 
 import httpx
 from fastapi import HTTPException, status
+
+logger = logging.getLogger(__name__)
 
 
 @contextlib.asynccontextmanager
@@ -13,3 +16,22 @@ async def wrap_http_error_in_502(base_msg: str = "Error in FinOps for Cloud"):
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=f"{base_msg}: {e.response.status_code} - {e.response.text}.",
         ) from e
+
+
+@contextlib.asynccontextmanager
+async def wrap_exc_in_http_response(
+    exc_cls: type[Exception],
+    error_msg: str | None = None,
+    status_code: int = status.HTTP_400_BAD_REQUEST,
+):
+    try:
+        yield
+    except exc_cls as e:
+        if error_msg is None:
+            error_msg = str(e)
+
+        logger.exception(
+            f"{exc_cls.__name__} error was raised during an operation, "
+            f"returning a {status_code} HTTP response: {error_msg}"
+        )
+        raise HTTPException(status_code=status_code, detail=error_msg) from e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,11 +2,11 @@
 name = "mpt-finops-operations"
 version = "0.1.0"
 description = "SWO FinOps For Cloud Operations API"
-readme = {file = "README.md", content-type = "text/markdown"}
+readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
-    {name = "SoftwareOne AG"},
+    { name = "SoftwareOne AG" },
 ]
-license = {file = "LICENSE.txt"}
+license = { file = "LICENSE.txt" }
 requires-python = ">=3.12,<4"
 dependencies = [
     "alembic==1.14.*",
@@ -70,16 +70,19 @@ extend-exclude = [
 cache-dir = ".cache/ruff"
 
 [tool.ruff.lint]
+preview = true # enable linting rules in preview (e.g. RUF029 as of 2025-02-20)
+explicit-preview-rules = true # only enable preview rules we explicitly specify
 select = [
-    "E",  # w errors
-    "W",  # pycodestyle warnings
-    "F",  # pyflakes
-    "I",  # isort
-    "B",  # flake8-bugbear
-    "C4",  # flake8-comprehensions
-    "UP",  # pyupgrade,
-    "PT",  # flake8-pytest-style
-    "T10",  # flake8-pytest-style
+    "E",      # w errors
+    "W",      # pycodestyle warnings
+    "F",      # pyflakes
+    "I",      # isort
+    "B",      # flake8-bugbear
+    "C4",     # flake8-comprehensions
+    "UP",     # pyupgrade,
+    "PT",     # flake8-pytest-style
+    "T10",    # flake8-pytest-style
+    "RUF029", # unused-async
 ]
 ignore = [
     "PT001", # Use `@pytest.fixture()` over `@pytest.fixture`

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,2 @@
+[formatting]
+array_auto_collapse = false # Automatically collapse arrays if they fit in one line.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,7 @@ def db_engine(test_settings: Settings) -> AsyncEngine:
 
 
 @pytest.fixture(scope="session")
-async def fastapi_app(test_settings: Settings) -> FastAPI:
+def fastapi_app(test_settings: Settings) -> FastAPI:
     from app.main import app
 
     app.dependency_overrides[get_settings] = lambda: test_settings

--- a/tests/test_accounts_api.py
+++ b/tests/test_accounts_api.py
@@ -325,20 +325,20 @@ async def test_validate_account_type_and_required_conditions_account_deleted(
     )
 
 
-async def test_validate_required_conditions_before_update_account_type_operations(
+def test_validate_required_conditions_before_update_account_type_operations(
     operations_account: Account,
 ):
     with pytest.raises(HTTPException) as exc_info:
-        await validate_required_conditions_before_update(account=operations_account)
+        validate_required_conditions_before_update(account=operations_account)
     assert exc_info.value.status_code == 400
     assert exc_info.value.detail == "You cannot update an Account of type Operations."
 
 
-async def test_validate_required_conditions_before_update_account_deleted():
+def test_validate_required_conditions_before_update_account_deleted():
     account = Account(name="Microsoft", external_id="ACC-9044-8753", type=AccountType.AFFILIATE)
     account.status = AccountStatus.DELETED
     with pytest.raises(HTTPException) as exc_info:
-        await validate_required_conditions_before_update(account=account)
+        validate_required_conditions_before_update(account=account)
 
     assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
     assert "You cannot update an Account Deleted." in str(exc_info.value.detail)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -250,7 +250,6 @@ async def test_get_authentication_context_user_account_does_not_exist(
         auth_context.get()
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("account_type", "should_raise_exception", "expected_status", "expected_detail"),
     [
@@ -263,7 +262,7 @@ async def test_get_authentication_context_user_account_does_not_exist(
         (AccountType.OPERATIONS, False, None, None),
     ],
 )
-async def test_check_operations_account(
+def test_check_operations_account(
     mocker: MockerFixture,
     account_type: AccountType,
     should_raise_exception: bool,
@@ -274,10 +273,10 @@ async def test_check_operations_account(
     context.account.type = account_type
     if should_raise_exception:
         with pytest.raises(HTTPException) as exc_info:
-            await check_operations_account(context)
+            check_operations_account(context)
 
         assert exc_info.value.status_code == expected_status
         assert expected_detail in str(exc_info.value.detail)
     else:
-        result = await check_operations_account(context)
+        result = check_operations_account(context)
         assert result is None

--- a/tests/test_systems_api.py
+++ b/tests/test_systems_api.py
@@ -34,7 +34,6 @@ async def test_get_system_by_id(
     assert data["name"] == gcp_extension.name
     assert data["external_id"] == gcp_extension.external_id
     assert data["description"] == gcp_extension.description
-    assert data["jwt_secret"] == gcp_extension.jwt_secret
     assert data["owner"]["id"] == gcp_extension.owner_id
     assert datetime.fromisoformat(data["created_at"]) == gcp_extension.created_at
     assert datetime.fromisoformat(data["updated_at"]) == gcp_extension.updated_at
@@ -44,6 +43,8 @@ async def test_get_system_by_id(
     assert data["updated_by"] == gcp_extension.updated_by
     assert data["deleted_by"] is None
     assert data["status"] == gcp_extension.status._value_
+
+    assert "jwt_secret" not in data
 
 
 async def test_get_system_by_id_no_auth(
@@ -81,6 +82,8 @@ async def test_get_system_with_deleted_status(
     assert data["id"] == second_active_system.id
     assert data["status"] == "active"
 
+    assert "jwt_secret" not in data
+
     response = await api_client.get(
         f"/systems/{deleted_system.id}",
         headers={"Authorization": f"Bearer {system_jwt_token_factory(first_active_system)}"},
@@ -95,6 +98,8 @@ async def test_get_system_with_deleted_status(
 
     assert data["id"] == deleted_system.id
     assert data["status"] == "deleted"
+
+    assert "jwt_secret" not in data
 
 
 async def test_get_system_by_id_auth_different_account(
@@ -157,8 +162,13 @@ async def test_get_all_systems_single_active_record(
     )
 
     assert response.status_code == 200
-    assert response.json()["total"] == 1
-    assert response.json()["items"][0]["id"] == gcp_extension.id
+
+    data = response.json()
+
+    assert data["total"] == 1
+    assert data["items"][0]["id"] == gcp_extension.id
+
+    assert "jwt_secret" not in data["items"][0]
 
 
 async def test_get_all_systems_multiple_systems_single_account(
@@ -352,6 +362,7 @@ async def test_disable_system(
     else:
         data = response.json()
         assert data["status"] == expected_new_status._value_
+        assert "jwt_secret" not in data
 
     await db_session.refresh(system)
     assert system.status == expected_new_status
@@ -438,6 +449,7 @@ async def test_enable_system(
     else:
         data = response.json()
         assert data["status"] == expected_new_status._value_
+        assert "jwt_secret" not in data
 
     await db_session.refresh(system)
     assert system.status == expected_new_status
@@ -665,6 +677,8 @@ async def test_update_system(
         assert response_data["description"] == expected_description
         assert response_data["external_id"] == expected_external_id
 
+        assert "jwt_secret" not in response_data
+
     await db_session.refresh(system)
 
     assert system.name == expected_name
@@ -720,6 +734,7 @@ async def test_system_external_id_is_unique_for_non_deleted_objects(
     await db_session.refresh(system)
 
     if expected_status_code == status.HTTP_200_OK:
+        assert "jwt_secret" not in response_data
         assert response_data["external_id"] == "existing_external_id"
         assert system.external_id == "existing_external_id"
     else:
@@ -849,10 +864,11 @@ async def test_create_system_by_operations_account(
             assert response_data["description"] is None
             assert db_system.description is None
 
+        assert "jwt_secret" in response_data
+
         if "jwt_secret" in input_data:
             assert response_data["jwt_secret"] == input_data["jwt_secret"] == db_system.jwt_secret
         else:
-            assert "jwt_secret" in response_data
             assert len(response_data["jwt_secret"]) >= 64
             assert response_data["jwt_secret"] == db_system.jwt_secret
 
@@ -899,6 +915,8 @@ async def test_create_system_with_different_owners(
     else:
         raise RuntimeError("invalid branch")
 
+    owner_json_field = {"owner": {"id": owner_id}} if owner_id != creator_account.id else {}
+
     response = await api_client.post(
         "/systems",
         headers={"Authorization": f"Bearer {system_jwt_token_factory(creator_system)}"},
@@ -906,11 +924,14 @@ async def test_create_system_with_different_owners(
             "name": "test system",
             "external_id": "test-system",
             "description": "test description",
-            "owner": {"id": owner_id},
+            **owner_json_field,
         },
     )
 
     assert response.status_code == expected_status_code
+
+    if not response.is_error:
+        assert "jwt_secret" in response.json()
 
 
 @pytest.mark.parametrize(
@@ -957,3 +978,4 @@ async def test_create_system_duplicate_external_id_with_deleted(
     else:
         assert response_data["external_id"] == "existing_external_id"
         assert created_system.external_id == "existing_external_id"
+        assert "jwt_secret" in response_data


### PR DESCRIPTION
* system create: `data.owner` is mandatory only for Operators and is forbidden for affiliates (just like entitlements)
* JWT token is returned only in the system create response (incl. tests that we don't accidentally return it in other endpoints responses)
* Add logging and improve readability when handling exceptions in routes
