### PR TITLE
feat: Automate audit fields with sqlalchemy hooks

### DIFF
--- a/tests/api/test_systems_api.py
+++ b/tests/api/test_systems_api.py
@@ -518,6 +518,19 @@ async def test_delete_system(
         assert system.deleted_at is not None
         assert system.deleted_by is ffc_extension
 
+        # TODO: extract me into a proper test
+
+        # Make sure that the deleted_at and deleted_by fields are not changed if the status hasn't
+        # changed
+
+        system.name = "asd"
+        db_session.add(system)
+        await db_session.commit()
+        await db_session.refresh(system)
+        assert system.deleted_at is not None
+        assert system.deleted_by is ffc_extension
+        assert system.name == "asd"
+
 
 async def test_system_cannot_delete_itself(
     system_factory: ModelFactory[System],


### PR DESCRIPTION
Automatically set `created_by`, `updated_by`, `created_at`, `updated_at`, `deleted_by` and `deleted_at` without using the handlers.

Why? Not every model creation goes through the handlers in practice (e.g. tests, commands) -- even if we change our habits, there is no way to enforce this and sqlalchemy has built-in mechanisms for this anyway. This is important as otherwise the models are not properly audited and may contain wrong data. Also I was bored :D  As a side effect the handlers look more readable (as they focus on the main business logic) and we can even remove the `soft_delete` method (it's effectively just `self.update({"status": "deleted"})` at this point.

Intentionally leaving this in draft state as it's not complete (a few todos and missing proper tests) -- will wait for feedback before finishing it up.

We can also use hooks like this for selects (e.g. when an affiliate user queries data, `status != 'deleted'` is automatically applied) and this will simplify our codebase even further. But we need to be careful to not affect useful error messages.