### PR TITLE
feat: Fetch exchange rates for multiple base currencies (MPT-8606)

### DIFF
--- a/app/commands/generate_monthly_charges.py
+++ b/app/commands/generate_monthly_charges.py
@@ -493,7 +493,7 @@ async def main(exports_dir: pathlib.Path, settings: Settings) -> None:
     async with session_factory() as session:
         async with session.begin():
             unique_billing_currencies = await fetch_unique_billing_currencies(session)
-            currency_converter = await CurrencyConverter.from_db(session)
+            currency_converter = await CurrencyConverter.from_db(session, "USD")
             accounts = await fetch_accounts(session)
 
         for currency in unique_billing_currencies:

--- a/app/commands/update_latest_exchange_rates.py
+++ b/app/commands/update_latest_exchange_rates.py
@@ -1,49 +1,105 @@
 import asyncio
 import logging
+from collections.abc import Sequence
+from typing import Any
 
 import typer
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api_clients.exchange_rate import ExchangeRateAPIClient
 from app.conf import Settings
 from app.db.base import session_factory
 from app.db.handlers import ExchangeRatesHandler
-from app.db.models import ExchangeRates
+from app.db.models import ExchangeRates, Organization
 
 logger = logging.getLogger(__name__)
 
 
+async def fetch_unique_currencies(session: AsyncSession) -> Sequence[str]:
+    logger.info("Fetching all the unique currencies from the database")
+
+    currencies_stmt = select(Organization.currency).distinct().order_by(Organization.currency.asc())
+
+    currencies = (await session.scalars(currencies_stmt)).all()
+
+    logger.info(
+        "Found the following unique currencies from the database: %s", ", ".join(currencies)
+    )
+    return currencies
+
+
+async def get_currencies_to_update(session: AsyncSession) -> list[str]:
+    exchange_rates_handler = ExchangeRatesHandler(session)
+    all_currencies = await fetch_unique_currencies(session)
+
+    currencies_to_update = []
+
+    for base_currency in all_currencies:
+        latest_exchange_rates = await exchange_rates_handler.fetch_latest_valid(base_currency)
+
+        if latest_exchange_rates is not None:
+            logger.info(
+                "Exchange rates for %s are already stored in the database and are still valid, "
+                "skipping feching them",
+                base_currency,
+            )
+            continue
+
+        logger.info(
+            "Exchange rates for %s are not stored in the database or are no longer valid, "
+            "adding the currency to the list to be fetched",
+            base_currency,
+        )
+
+        currencies_to_update.append(base_currency)
+
+    if currencies_to_update:
+        logger.info(
+            "The following currencies will be updated with their latest exchange rates: %s",
+            ", ".join(currencies_to_update),
+        )
+
+    return currencies_to_update
+
+
 async def main(settings: Settings) -> None:
     async with session_factory() as session:
-        exchange_rates_handler = ExchangeRatesHandler(session)
-
         async with session.begin():
-            latest_exchange_rates = await exchange_rates_handler.fetch_latest_valid()
+            currencies_to_update = await get_currencies_to_update(session)
 
-            if latest_exchange_rates is not None:
-                logger.info("Exchange rates are already stored in the database and are still valid")
-                logger.info("Skipping fetching exchange rates")
-                return
+        if not currencies_to_update:
+            logger.info("No currencies to update, exiting")
+            return
 
-            logger.info("Exchange rates are not stored in the database or are no longer valid")
+        exchange_rates_per_currency: dict[str, dict[str, Any]] = {}
 
-        logger.info("Fetching latest exchange rates against USD")
         async with ExchangeRateAPIClient(settings) as exchange_rate_client:
-            try:
-                response = await exchange_rate_client.get_latest_rates(base_currency="USD")
-            except Exception as e:
-                logger.exception("Failed to fetch exchange rates due to an exception")
-                raise e
+            for base_currency in currencies_to_update:
+                logger.info("Fetching latest exchange rates for %s", base_currency)
 
-            exchange_rates = response.json()
+                try:
+                    response = await exchange_rate_client.get_latest_rates(base_currency)
+                except Exception:
+                    logger.exception(
+                        f"Failed to fetch exchange rates for {base_currency} due to an exception"
+                    )
+                    continue
 
-        logger.info("Successfully fetched exchange rates")
+                logger.info("Successfully fetched exchange rates for %s", base_currency)
+                exchange_rates_per_currency[base_currency] = response.json()
 
-        logger.info("Storing latest exchange rates into the database")
         async with session.begin():
-            exchange_rates_model = ExchangeRates(api_response=exchange_rates)
-            session.add(exchange_rates_model)
+            for base_currency, api_response in exchange_rates_per_currency.items():
+                logger.info("Storing latest exchange rates for %s into the database", base_currency)
 
-        logger.info("Completed storing exchange rates")
+                exchange_rates_model = ExchangeRates(api_response=api_response)
+                session.add(exchange_rates_model)
+
+        if exchange_rates_per_currency:
+            logger.info(
+                "Completed storing exchange rates for %s", ", ".join(exchange_rates_per_currency)
+            )
 
 
 def command(ctx: typer.Context) -> None:

--- a/app/currency.py
+++ b/app/currency.py
@@ -34,9 +34,9 @@ class CurrencyConverter:
         self.exchange_rates_db_record = exchange_rates_db_record
 
     @classmethod
-    async def from_db(cls, db_session: AsyncSession) -> Self:
+    async def from_db(cls, db_session: AsyncSession, base_currency: str) -> Self:
         exchange_rates_handler = ExchangeRatesHandler(db_session)
-        exchange_rates = await exchange_rates_handler.fetch_latest_valid()
+        exchange_rates = await exchange_rates_handler.fetch_latest_valid(base_currency)
 
         if exchange_rates is None:
             raise CurrencyConverterError("No active exchange rates found in the database")

--- a/app/db/handlers.py
+++ b/app/db/handlers.py
@@ -512,9 +512,10 @@ class ChargesFileHandler(ModelHandler[ChargesFile]):
 
 
 class ExchangeRatesHandler(ModelHandler[ExchangeRates]):
-    async def fetch_latest_valid(self) -> ExchangeRates | None:
+    async def fetch_latest_valid(self, base_currency: str) -> ExchangeRates | None:
         scalars = await self.query_db(
             select(ExchangeRates)
+            .filter(ExchangeRates.base_currency == base_currency)
             .filter(ExchangeRates.next_update > datetime.now(UTC))
             .order_by(desc(ExchangeRates.last_update))
             .limit(1)

--- a/tests/commands/test_generate_monthtly_charges.py
+++ b/tests/commands/test_generate_monthtly_charges.py
@@ -397,7 +397,7 @@ async def test_export_to_zip(
         },
     )
 
-    currency_converter = await CurrencyConverter.from_db(db_session)
+    currency_converter = await CurrencyConverter.from_db(db_session, "USD")
 
     charges_file_generator = ChargesFileGenerator(
         operations_account, "EUR", currency_converter, tmp_path

--- a/tests/commands/test_update_latest_exchange_rates.py
+++ b/tests/commands/test_update_latest_exchange_rates.py
@@ -12,96 +12,101 @@ from app.cli import app
 from app.commands import update_latest_exchange_rates
 from app.conf import Settings
 from app.db.handlers import ExchangeRatesHandler
-from app.db.models import ExchangeRates
+from app.db.models import ExchangeRates, Organization
 from tests.fixtures.mock_api_clients import MockExchangeRateAPIClient
 from tests.types import ModelFactory
 
 
 @time_machine.travel("2025-03-26T10:00:00Z", tick=False)
-async def test_successful_fetch_exchange_rates_when_missing(
+async def test_successful_fetch_exchange_rates_when_missing_multiple_currencies(
+    organization_factory: ModelFactory[Organization],
+    exchange_rates_per_currency: dict[str, dict[str, float]],
     test_settings: Settings,
     db_session: AsyncSession,
     mock_exchange_rate_api_client: MockExchangeRateAPIClient,
     time_machine: time_machine.TimeMachineFixture,
     caplog: pytest.LogCaptureFixture,
 ):
+    await organization_factory(currency="USD", operations_external_id="ORG-123")
+    # intentional duplicate to test that we only fetch USD exchange rates once
+    await organization_factory(currency="USD", operations_external_id="ORG-456")
+    await organization_factory(currency="GBP", operations_external_id="ORG-789")
+    await organization_factory(currency="EUR", operations_external_id="ORG-987")
+
     exchange_rates_handler = ExchangeRatesHandler(db_session)
 
     existing_exchange_rates = await exchange_rates_handler.query_db()
     assert len(existing_exchange_rates) == 0
-    mock_exchange_rate_api_client.mock_get_latest_rates(
-        base_currency="USD",
-        exchange_rates={
-            "USD": 1.0,
-            "EUR": 0.9252,
-            "GBP": 0.7737,
-        },
-    )
+
+    for base_currency in exchange_rates_per_currency:
+        mock_exchange_rate_api_client.mock_get_latest_rates(base_currency=base_currency)
 
     with caplog.at_level(logging.INFO, logger="app.commands.update_latest_exchange_rates"):
         await update_latest_exchange_rates.main(test_settings)
 
-    assert caplog.messages == [
-        "Exchange rates are not stored in the database or are no longer valid",
-        "Fetching latest exchange rates against USD",
-        "Successfully fetched exchange rates",
-        "Storing latest exchange rates into the database",
-        "Completed storing exchange rates",
-    ]
+    for base_currency, currency_rates in exchange_rates_per_currency.items():
+        assert (
+            f"Exchange rates for {base_currency} are not stored in the database or "
+            "are no longer valid, adding the currency to the list to be fetched"
+        ) in caplog.messages
+        assert f"Successfully fetched exchange rates for {base_currency}" in caplog.messages
+        assert (
+            f"Storing latest exchange rates for {base_currency} into the database"
+            in caplog.messages
+        )
 
-    new_exchange_rates = await exchange_rates_handler.query_db()
-    assert len(new_exchange_rates) == 1
+        exchange_rates = await exchange_rates_handler.fetch_latest_valid(base_currency)
 
-    exchange_rates = new_exchange_rates[0]
+        assert exchange_rates is not None
+        assert exchange_rates.api_response["base_code"] == base_currency
+        assert exchange_rates.api_response["conversion_rates"] == currency_rates
 
-    assert exchange_rates.api_response["base_code"] == "USD"
-    assert exchange_rates.api_response["conversion_rates"] == {
-        "USD": 1.0,
-        "EUR": 0.9252,
-        "GBP": 0.7737,
-    }
-
-    assert exchange_rates.base_currency == exchange_rates.api_response["base_code"]
-    assert exchange_rates.last_update == datetime.fromtimestamp(
-        exchange_rates.api_response["time_last_update_unix"], UTC
-    )
-    assert exchange_rates.next_update == datetime.fromtimestamp(
-        exchange_rates.api_response["time_next_update_unix"], UTC
-    )
+        assert exchange_rates.last_update == datetime.fromtimestamp(
+            exchange_rates.api_response["time_last_update_unix"], UTC
+        )
+        assert exchange_rates.next_update == datetime.fromtimestamp(
+            exchange_rates.api_response["time_next_update_unix"], UTC
+        )
 
 
 @time_machine.travel("2025-03-26T10:00:00Z", tick=False)
 async def test_dont_fetch_exchange_rates_when_recent_are_present_in_db(
+    organization_factory: ModelFactory[Organization],
     test_settings: Settings,
     db_session: AsyncSession,
     mock_exchange_rate_api_client: MockExchangeRateAPIClient,
     exchange_rates_factory: ModelFactory[ExchangeRates],
     caplog: pytest.LogCaptureFixture,
 ):
-    await exchange_rates_factory()
+    await organization_factory(currency="USD")
+    await exchange_rates_factory(base_currency="USD")
 
     with caplog.at_level(logging.INFO, logger="app.commands.update_latest_exchange_rates"):
         await update_latest_exchange_rates.main(test_settings)
 
-    assert caplog.messages == [
-        "Exchange rates are already stored in the database and are still valid",
-        "Skipping fetching exchange rates",
-    ]
+    assert (
+        "Exchange rates for USD are already stored in the database and are still valid, "
+        "skipping feching them" in caplog.messages
+    )
 
     mock_exchange_rate_api_client.assert_no_api_calls()
 
 
 @time_machine.travel("2025-03-26T10:00:00Z", tick=False)
 async def test_fetch_exchange_rates_when_outdated_are_present_in_db(
+    organization_factory: ModelFactory[Organization],
     test_settings: Settings,
     db_session: AsyncSession,
     mock_exchange_rate_api_client: MockExchangeRateAPIClient,
     exchange_rates_factory: ModelFactory[ExchangeRates],
     caplog: pytest.LogCaptureFixture,
 ):
+    await organization_factory(currency="USD")
+
     exchange_rates_handler = ExchangeRatesHandler(db_session)
 
     await exchange_rates_factory(
+        base_currency="USD",
         last_update=datetime.now(UTC) - timedelta(days=1),
         next_update=datetime.now(UTC) - timedelta(minutes=1),
     )
@@ -117,18 +122,17 @@ async def test_fetch_exchange_rates_when_outdated_are_present_in_db(
     with caplog.at_level(logging.INFO, logger="app.commands.update_latest_exchange_rates"):
         await update_latest_exchange_rates.main(test_settings)
 
-    assert caplog.messages == [
-        "Exchange rates are not stored in the database or are no longer valid",
-        "Fetching latest exchange rates against USD",
-        "Successfully fetched exchange rates",
-        "Storing latest exchange rates into the database",
-        "Completed storing exchange rates",
-    ]
+    assert (
+        "Exchange rates for USD are not stored in the database or are no longer valid, "
+        "adding the currency to the list to be fetched"
+    ) in caplog.messages
+    assert "Fetching latest exchange rates for USD" in caplog.messages
+    assert "Completed storing exchange rates for USD" in caplog.messages
 
     new_exchange_rates = await exchange_rates_handler.query_db()
     assert len(new_exchange_rates) == 2
 
-    latest_exchange_rates = await exchange_rates_handler.fetch_latest_valid()
+    latest_exchange_rates = await exchange_rates_handler.fetch_latest_valid("USD")
 
     assert latest_exchange_rates is not None
     assert latest_exchange_rates.api_response["conversion_rates"] == {
@@ -140,75 +144,70 @@ async def test_fetch_exchange_rates_when_outdated_are_present_in_db(
 
 @time_machine.travel("2025-03-26T10:00:00Z", tick=False)
 async def test_exchange_rate_api_rerturns_unrecoverable_error(
+    organization_factory: ModelFactory[Organization],
     test_settings: Settings,
     db_session: AsyncSession,
     mock_exchange_rate_api_client: MockExchangeRateAPIClient,
     caplog: pytest.LogCaptureFixture,
 ):
+    await organization_factory(currency="USD")
     exchange_rates_handler = ExchangeRatesHandler(db_session)
 
     mock_exchange_rate_api_client.mock_get_latest_rates(
-        error_code=ExchangeRateAPIErrorType.INACTIVE_ACCOUNT
+        base_currency="USD", error_code=ExchangeRateAPIErrorType.INACTIVE_ACCOUNT
     )
 
     with caplog.at_level(logging.INFO, logger="app.commands.update_latest_exchange_rates"):
-        with pytest.raises(ExchangeRateAPIError) as exc_info:
-            await update_latest_exchange_rates.main(test_settings)
+        await update_latest_exchange_rates.main(test_settings)
 
-    assert exc_info.value.error_type == ExchangeRateAPIErrorType.INACTIVE_ACCOUNT
+    assert "Fetching latest exchange rates for USD" in caplog.messages
+    assert "Failed to fetch exchange rates for USD due to an exception" in caplog.messages
 
-    assert caplog.messages == [
-        "Exchange rates are not stored in the database or are no longer valid",
-        "Fetching latest exchange rates against USD",
-        "Failed to fetch exchange rates due to an exception",
-    ]
-
-    assert caplog.records[-1].exc_info is not None
+    log_with_exception = next(
+        record for record in caplog.records if "Failed to fetch exchange rates" in record.message
+    )
+    assert log_with_exception.levelno == logging.ERROR
+    assert log_with_exception.exc_info is not None
+    exc_type, exc_value, traceback = log_with_exception.exc_info
+    assert exc_type is ExchangeRateAPIError
+    assert exc_value.error_type == ExchangeRateAPIErrorType.INACTIVE_ACCOUNT  # type: ignore[union-attr]
+    assert traceback is not None
 
     assert not await exchange_rates_handler.query_db()
 
 
 @time_machine.travel("2025-03-26T10:00:00Z", tick=False)
 async def test_exchange_rate_api_timeouts_then_succeeds(
+    organization_factory: ModelFactory[Organization],
+    exchange_rates_per_currency: dict[str, dict[str, float]],
     test_settings: Settings,
     db_session: AsyncSession,
     mock_exchange_rate_api_client: MockExchangeRateAPIClient,
     caplog: pytest.LogCaptureFixture,
 ):
+    await organization_factory(currency="USD")
     exchange_rates_handler = ExchangeRatesHandler(db_session)
 
     mock_exchange_rate_api_client.simulate_read_timeout()
-    mock_exchange_rate_api_client.mock_get_latest_rates(
-        base_currency="USD",
-        exchange_rates={
-            "USD": 1.0,
-            "EUR": 0.9252,
-            "GBP": 0.7737,
-        },
-    )
+    mock_exchange_rate_api_client.mock_get_latest_rates(base_currency="USD")
 
     with caplog.at_level(logging.INFO, logger="app.commands.update_latest_exchange_rates"):
         await update_latest_exchange_rates.main(test_settings)
 
-    latest_exchange_rates = await exchange_rates_handler.fetch_latest_valid()
+    latest_exchange_rates = await exchange_rates_handler.fetch_latest_valid("USD")
 
     assert latest_exchange_rates is not None
-    assert latest_exchange_rates.api_response["conversion_rates"] == {
-        "USD": 1.0,
-        "EUR": 0.9252,
-        "GBP": 0.7737,
-    }
+    assert (
+        latest_exchange_rates.api_response["conversion_rates"] == exchange_rates_per_currency["USD"]
+    )
 
-    assert caplog.messages == [
-        "Exchange rates are not stored in the database or are no longer valid",
-        "Fetching latest exchange rates against USD",
-        "stamina.retry_scheduled",
-        "Successfully fetched exchange rates",
-        "Storing latest exchange rates into the database",
-        "Completed storing exchange rates",
-    ]
+    assert "Fetching latest exchange rates for USD" in caplog.messages
+    assert "stamina.retry_scheduled" in caplog.messages
+    assert "Successfully fetched exchange rates for USD" in caplog.messages
 
-    stamina_log = caplog.records[2]
+    stamina_log = next(
+        record for record in caplog.records if "stamina.retry_scheduled" in record.message
+    )
     stamina_log_extra = stamina_log.__dict__
 
     assert stamina_log_extra["stamina.caused_by"] == "ReadTimeout('Unable to read within timeout')"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -460,7 +460,31 @@ def datasource_expense_factory(
 
 
 @pytest.fixture
-def exchange_rates_factory(db_session: AsyncSession) -> ModelFactory[ExchangeRates]:
+def exchange_rates_per_currency() -> dict[str, dict[str, float]]:
+    return {
+        "USD": {
+            "USD": 1.0,
+            "EUR": 0.9252,
+            "GBP": 0.7737,
+        },
+        "EUR": {
+            "USD": 1.0808,
+            "EUR": 1.0,
+            "GBP": 0.8555,
+        },
+        "GBP": {
+            "USD": 1.2925,
+            "EUR": 1.1689,
+            "GBP": 1.0,
+        },
+    }
+
+
+@pytest.fixture
+def exchange_rates_factory(
+    db_session: AsyncSession,
+    exchange_rates_per_currency: dict[str, dict[str, float]],
+) -> ModelFactory[ExchangeRates]:
     async def _exchange_rates(
         exchange_rates: dict[str, float] | None = None,
         base_currency: str = "USD",
@@ -468,11 +492,7 @@ def exchange_rates_factory(db_session: AsyncSession) -> ModelFactory[ExchangeRat
         next_update: datetime | None = None,
     ):
         if exchange_rates is None:
-            exchange_rates = {
-                "USD": 1.0,
-                "EUR": 0.9252,
-                "GBP": 0.7737,
-            }
+            exchange_rates = exchange_rates_per_currency[base_currency]
 
         if last_update is None:
             last_update = datetime.now(UTC)

--- a/tests/fixtures/mock_api_clients.py
+++ b/tests/fixtures/mock_api_clients.py
@@ -133,6 +133,16 @@ def mock_optscale_client(test_settings: Settings, httpx_mock: HTTPXMock) -> Mock
 class MockExchangeRateAPIClient(BaseMockAPIClient[ExchangeRateAPIClient]):
     API_RESPONSE_DATETIME_FORMAT = "%a, %d %b %Y %H:%M:%S %z"
 
+    def __init__(
+        self,
+        test_settings: Settings,
+        httpx_mock: HTTPXMock,
+        default_exchange_rates: dict[str, dict[str, float]] | None = None,
+    ) -> None:
+        super().__init__(test_settings, httpx_mock)
+
+        self.default_exchange_rates = default_exchange_rates or {}
+
     def mock_get_latest_rates(
         self,
         exchange_rates: dict[str, float] | None = None,
@@ -141,6 +151,9 @@ class MockExchangeRateAPIClient(BaseMockAPIClient[ExchangeRateAPIClient]):
         next_update: datetime | None = None,
         error_code: ExchangeRateAPIErrorType | None = None,
     ) -> None:
+        if exchange_rates is None:
+            exchange_rates = self.default_exchange_rates.get(base_currency)
+
         if last_update is None:
             last_update = datetime.now(UTC)
 
@@ -173,5 +186,10 @@ class MockExchangeRateAPIClient(BaseMockAPIClient[ExchangeRateAPIClient]):
 def mock_exchange_rate_api_client(
     test_settings: Settings,
     httpx_mock: HTTPXMock,
+    exchange_rates_per_currency: dict[str, dict[str, float]],
 ) -> MockExchangeRateAPIClient:
-    return MockExchangeRateAPIClient(test_settings, httpx_mock)
+    return MockExchangeRateAPIClient(
+        test_settings,
+        httpx_mock,
+        default_exchange_rates=exchange_rates_per_currency,
+    )

--- a/tests/test_currency.py
+++ b/tests/test_currency.py
@@ -35,7 +35,7 @@ async def test_currency_converter_from_db(
         },
     )
 
-    currency_converter = await CurrencyConverter.from_db(db_session)
+    currency_converter = await CurrencyConverter.from_db(db_session, "USD")
     assert currency_converter.base_currency == exchange_rates.base_currency
     assert currency_converter.exchange_rates == {
         ccy: Decimal(rate).quantize(Decimal("0.1") ** CurrencyConverter.DECIMAL_PRECISION)
@@ -49,7 +49,7 @@ async def test_currency_converter_from_db_no_db_records(db_session: AsyncSession
     with pytest.raises(
         CurrencyConverterError, match="No active exchange rates found in the database"
     ):
-        await CurrencyConverter.from_db(db_session)
+        await CurrencyConverter.from_db(db_session, "USD")
 
 
 @time_machine.travel("2025-03-28T10:00:00Z", tick=False)
@@ -65,7 +65,7 @@ async def test_currency_converter_from_db_only_old_records(
     with pytest.raises(
         CurrencyConverterError, match="No active exchange rates found in the database"
     ):
-        await CurrencyConverter.from_db(db_session)
+        await CurrencyConverter.from_db(db_session, "USD")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is the first PR covering only fetching rates for other base currencies to make it easier to review. In future PRs I'll cover changing the conversion logic to take into account the other base currency exchange rates and exporting the correct Exchangerates API response when generating charges files