### PR TITLE
feat: Fix issues caused by SQLAlchemy OptenTelemetry grouping by transaction (MPT-11422)

### DIFF
--- a/app/commands/calculate_accounts_stats.py
+++ b/app/commands/calculate_accounts_stats.py
@@ -8,7 +8,7 @@ from app.db.base import session_factory
 from app.db.handlers import AccountHandler, EntitlementHandler
 from app.db.models import Account
 from app.enums import AccountStatus, EntitlementStatus
-from app.telemetry import capture_telemetry
+from app.telemetry import capture_telemetry_cli_command
 
 BATCH_SIZE = 100
 
@@ -16,7 +16,7 @@ BATCH_SIZE = 100
 logger = logging.getLogger(__name__)
 
 
-@capture_telemetry(__name__, "Calculate Accounts Stats")
+@capture_telemetry_cli_command(__name__, "Calculate Accounts Stats")
 async def calculate_accounts_stats(settings: Settings):
     """
     This command calculates the stats about all the entitlements linked to

--- a/app/commands/check_expired_invitations.py
+++ b/app/commands/check_expired_invitations.py
@@ -10,12 +10,12 @@ from app.db.base import session_factory
 from app.db.models import Account, AccountUser, User
 from app.enums import AccountUserStatus
 from app.notifications import NotificationDetails, send_info
-from app.telemetry import capture_telemetry
+from app.telemetry import capture_telemetry_cli_command
 
 logger = logging.getLogger(__name__)
 
 
-@capture_telemetry(__name__, "Check Expired Invitations")
+@capture_telemetry_cli_command(__name__, "Check Expired Invitations")
 async def check_expired_invitations(settings: Settings):
     async with session_factory.begin() as session:
         stmt = (

--- a/app/commands/cleanup_obsolete_datasource_expenses.py
+++ b/app/commands/cleanup_obsolete_datasource_expenses.py
@@ -10,12 +10,12 @@ from app.conf import Settings
 from app.db.base import session_factory
 from app.db.models import DatasourceExpense
 from app.notifications import send_info
-from app.telemetry import capture_telemetry
+from app.telemetry import capture_telemetry_cli_command
 
 logger = logging.getLogger(__name__)
 
 
-@capture_telemetry(__name__, "Cleanup Obsolete Datasource Expenses")
+@capture_telemetry_cli_command(__name__, "Cleanup Obsolete Datasource Expenses")
 async def main(settings: Settings) -> None:
     async with session_factory.begin() as session:
         logger.info("Fetching obsolete datasource expenses from the database")

--- a/app/commands/fetch_datasource_expenses.py
+++ b/app/commands/fetch_datasource_expenses.py
@@ -14,7 +14,7 @@ from app.db.handlers import DatasourceExpenseHandler, OrganizationHandler
 from app.db.models import DatasourceExpense, Organization
 from app.enums import DatasourceType
 from app.notifications import send_exception, send_info
-from app.telemetry import capture_telemetry
+from app.telemetry import capture_telemetry_cli_command
 
 logger = logging.getLogger(__name__)
 
@@ -137,7 +137,7 @@ async def store_datasource_expenses(
     await send_info("Datasource Expenses Update Success", msg)
 
 
-@capture_telemetry(__name__, "Update Current Month Datasource Expenses")
+@capture_telemetry_cli_command(__name__, "Update Current Month Datasource Expenses")
 async def main(settings: Settings) -> None:
     today = datetime.now(UTC).date()
 

--- a/app/commands/redeem_entitlements.py
+++ b/app/commands/redeem_entitlements.py
@@ -13,7 +13,7 @@ from app.db.handlers import EntitlementHandler, OrganizationHandler
 from app.db.models import Entitlement, Organization
 from app.enums import EntitlementStatus, OrganizationStatus
 from app.notifications import NotificationDetails, send_exception, send_info
-from app.telemetry import capture_telemetry
+from app.telemetry import capture_telemetry_cli_command
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +94,7 @@ async def process_datasource(
         await send_exception("Redeem Entitlements Error", msg)
 
 
-@capture_telemetry(__name__, "Redeem Entitlements")
+@capture_telemetry_cli_command(__name__, "Redeem Entitlements")
 async def redeem_entitlements(settings: Settings):
     # FIXME: Long-lived DB transaction (making API calls inside the transaction)
 

--- a/app/commands/serve.py
+++ b/app/commands/serve.py
@@ -74,8 +74,7 @@ def command(
         ),
     ] = False,
 ):
-    """
-    Run the application with Gunicorn and Uvicorn workers."""
+    """Run the application with Gunicorn and Uvicorn workers."""
     options = {
         "bind": f"{host}:{port}",
         "workers": workers,

--- a/app/conf.py
+++ b/app/conf.py
@@ -59,10 +59,8 @@ class Settings(BaseSettings):
     cli_rich_logging: bool = True
     debug: bool = False
 
-    opentelemetry_exporter: OpenTelemetryExporter | None = OpenTelemetryExporter.JAEGER
-    jaeger_host: str = "jaeger"
-    jaeger_port: int = 4318
-    azure_insights_connection_string: str | None = None
+    opentelemetry_exporter: OpenTelemetryExporter = OpenTelemetryExporter.JAEGER
+    opentelemetry_connection_string: str | None = "http://jaeger:4318/v1/traces"
     opentelemetry_sqlalchemy_min_query_duration_ms: int | None = 100
 
     msteams_notifications_webhook_url: str | None = None
@@ -88,10 +86,6 @@ class Settings(BaseSettings):
             port=self.postgres_port,
             path=self.postgres_db,
         )
-
-    @computed_field
-    def jaeger_endpoint(self) -> str:
-        return f"http://{self.jaeger_host}:{self.jaeger_port}/v1/traces"
 
 
 _settings = None

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Callable, Coroutine
 from functools import wraps
 from typing import Any
@@ -7,51 +8,165 @@ from azure.monitor.opentelemetry.exporter import (
 )
 from fastapi import FastAPI
 from opentelemetry import trace
+from opentelemetry.context import Context
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 from opentelemetry.instrumentation.logging import LoggingInstrumentor
 from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.instrumentation.sqlalchemy.engine import EngineTracer
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor, TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter, SpanExporter
+from opentelemetry.semconv.trace import SpanAttributes
+from sqlalchemy import Connection
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-from app.conf import Settings
+from app.conf import OpenTelemetryExporter, Settings
+
+logger = logging.getLogger(__name__)
+
+SpanFilter = Callable[[ReadableSpan], bool]
 
 
-def setup_telemetry(settings: Settings) -> None:
-    if not settings.azure_insights_connection_string:
+def slow_sqlalchemy_queries(*, min_duration_ms: int) -> SpanFilter:  # pragma: no cover
+    def filter(span: ReadableSpan) -> bool:
+        if span.instrumentation_info.name != "opentelemetry.instrumentation.sqlalchemy":
+            # Apply this filter only for SQLAlchemy spans
+            return True
+
+        if not span.status.is_ok:
+            # Always include failed queries
+            return True
+
+        if span.end_time is None or span.start_time is None:
+            # execution time is unknown, always include it
+            return True
+
+        span_duration_ms = (span.end_time - span.start_time) / 1_000_000
+
+        return span_duration_ms >= min_duration_ms
+
+    return filter
+
+
+class FilteredSpanProcessor(SpanProcessor):  # pragma: no cover
+    def __init__(self, delegate_processor: SpanProcessor, filter_func: SpanFilter) -> None:
+        self.delegate_processor = delegate_processor
+        self.filter_func = filter_func
+
+    def on_start(self, span: Span, parent_context: Context | None = None) -> None:
+        self.delegate_processor.on_start(span, parent_context)
+
+    def on_end(self, span: ReadableSpan) -> None:
+        if not self.filter_func(span):
+            # If the span does not pass the filter, we drop it
+            return
+
+        self.delegate_processor.on_end(span)
+
+    def shutdown(self) -> None:
+        self.delegate_processor.shutdown()
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        return self.delegate_processor.force_flush(timeout_millis)
+
+
+def setup_telemetry(settings: Settings) -> None:  # pragma: no cover
+    if settings.opentelemetry_exporter is None:
         return
 
-    exporter = AzureMonitorTraceExporter(
-        connection_string=settings.azure_insights_connection_string,
+    resource = Resource(
+        attributes={"service.name": "ffc-operations-api"},
     )
+    trace_provider = TracerProvider(resource=resource)
 
-    trace_provider = TracerProvider()
-    trace_provider.add_span_processor(BatchSpanProcessor(exporter))
+    exporter: SpanExporter
+
+    if settings.opentelemetry_exporter == OpenTelemetryExporter.AZURE_APP_INSIGHTS:
+        exporter = AzureMonitorTraceExporter(
+            connection_string=settings.azure_insights_connection_string,
+        )
+    elif settings.opentelemetry_exporter == OpenTelemetryExporter.JAEGER:
+        exporter = OTLPSpanExporter(endpoint=settings.jaeger_endpoint)  # type: ignore[arg-type]
+    elif settings.opentelemetry_exporter == OpenTelemetryExporter.CONSOLE:
+        exporter = ConsoleSpanExporter()
+    else:
+        raise ValueError(f"Unsupported OpenTelemetry exporter: {settings.opentelemetry_exporter}")
+
+    span_processor: SpanProcessor = BatchSpanProcessor(exporter)
+
+    if settings.opentelemetry_sqlalchemy_min_query_duration_ms is not None:
+        span_processor = FilteredSpanProcessor(
+            span_processor,
+            slow_sqlalchemy_queries(
+                min_duration_ms=settings.opentelemetry_sqlalchemy_min_query_duration_ms
+            ),
+        )
+    trace_provider.add_span_processor(span_processor)
+
     trace.set_tracer_provider(trace_provider)
 
     HTTPXClientInstrumentor().instrument()
     LoggingInstrumentor().instrument(set_logging_format=True)
 
 
-def setup_fastapi_instrumentor(settings: Settings, app: FastAPI) -> None:
+def setup_fastapi_instrumentor(settings: Settings, app: FastAPI) -> None:  # pragma: no cover
     """
     Setup FastAPI instrumentation for the application.
     """
-    if not settings.azure_insights_connection_string:
+    if settings.opentelemetry_exporter is None:
         return
 
     FastAPIInstrumentor.instrument_app(app)
 
 
-def setup_sqlalchemy_instrumentor(settings: Settings, dbengine: AsyncEngine) -> None:
-    if not settings.azure_insights_connection_string:
+def setup_sqlalchemy_instrumentor(
+    settings: Settings, dbengine: AsyncEngine
+) -> None:  # pragma: no cover
+    if settings.opentelemetry_exporter is None:
         return
 
-    SQLAlchemyInstrumentor().instrument(engine=dbengine.sync_engine, enable_commenter=True)
+    engine_tracer: EngineTracer | None = SQLAlchemyInstrumentor().instrument(
+        engine=dbengine.sync_engine, enable_commenter=True
+    )
+
+    if engine_tracer is None:
+        return
+
+    def on_begin(conn: Connection) -> None:
+        transaction_span_ctx_mngr = engine_tracer.tracer.start_as_current_span(
+            "SQLAlchemy Transaction",
+            kind=trace.SpanKind.CLIENT,
+            attributes={
+                SpanAttributes.DB_NAME: dbengine.url.database,
+                SpanAttributes.DB_STATEMENT: "BEGIN",
+                SpanAttributes.DB_OPERATION: "BEGIN",
+            },
+        )
+
+        transaction_span_ctx_mngr.__enter__()
+
+        conn.info["otel_transaction_span_ctx_mngr"] = transaction_span_ctx_mngr
+
+    def on_commit(conn: Connection) -> None:
+        transaction_span_ctx_mngr = conn.info.pop("otel_transaction_span_ctx_mngr", None)
+
+        if transaction_span_ctx_mngr is not None:
+            transaction_span_ctx_mngr.__exit__(None, None, None)
+
+    def on_rollback(conn: Connection) -> None:
+        transaction_span_ctx_mngr = conn.info.pop("otel_transaction_span_ctx_mngr", None)
+
+        if transaction_span_ctx_mngr is not None:
+            transaction_span_ctx_mngr.__exit__(None, None, None)
+
+    engine_tracer._register_event_listener(dbengine.sync_engine, "begin", on_begin)
+    engine_tracer._register_event_listener(dbengine.sync_engine, "commit", on_commit)
+    engine_tracer._register_event_listener(dbengine.sync_engine, "rollback", on_rollback)
 
 
-def capture_telemetry[**P, R](
+def capture_telemetry_cli_command[**P, R](
     tracer_name: str, span_name: str
 ) -> Callable[[Callable[P, Coroutine[Any, Any, R]]], Callable[P, Coroutine[Any, Any, R]]]:
     def decorator(func: Callable[P, Coroutine[Any, Any, R]]) -> Callable[P, Coroutine[Any, Any, R]]:
@@ -59,7 +174,13 @@ def capture_telemetry[**P, R](
         async def _wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             tracer = trace.get_tracer(tracer_name)
 
-            with tracer.start_as_current_span(span_name, kind=trace.SpanKind.CLIENT):
+            with tracer.start_as_current_span(
+                span_name,
+                kind=trace.SpanKind.CLIENT,
+                attributes={
+                    "az.namespace": "CLI Command",
+                },
+            ):
                 return await func(*args, **kwargs)
 
         return _wrapper

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -80,10 +80,10 @@ def setup_telemetry(settings: Settings) -> None:  # pragma: no cover
 
     if settings.opentelemetry_exporter == OpenTelemetryExporter.AZURE_APP_INSIGHTS:
         exporter = AzureMonitorTraceExporter(
-            connection_string=settings.azure_insights_connection_string,
+            connection_string=settings.opentelemetry_connection_string
         )
     elif settings.opentelemetry_exporter == OpenTelemetryExporter.JAEGER:
-        exporter = OTLPSpanExporter(endpoint=settings.jaeger_endpoint)  # type: ignore[arg-type]
+        exporter = OTLPSpanExporter(endpoint=settings.opentelemetry_connection_string)  # type: ignore[arg-type]
     elif settings.opentelemetry_exporter == OpenTelemetryExporter.CONSOLE:
         exporter = ConsoleSpanExporter()
     else:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     depends_on:
       db:
         condition: "service_healthy"
-    command: bash -c "uv run fastapi dev --host 0.0.0.0 --port 8000"
+    command: bash -c "uv run ffcops serve"
     environment:
       FFC_OPERATIONS_POSTGRES_HOST: db
     env_file:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,7 @@ def test_settings() -> Settings:
     settings.api_modifier_jwt_secret = "test_jwt_secret"
     settings.auth_access_jwt_secret = "auth_access_jwt_secret"
     settings.auth_refresh_jwt_secret = "auth_refresh_jwt_secret"
+    settings.opentelemetry_exporter = None
     settings.smtp_sender_email = "test@example.com"
     settings.smtp_sender_name = "Test Sender"
     settings.smtp_host = "smtp.example.com"

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -10,7 +10,7 @@ from app.telemetry import (
 def test_setup_telemetry(mocker: MockerFixture):
     mock_settings = mocker.MagicMock()
     mock_settings.opentelemetry_exporter = "azure_app_insights"
-    mock_settings.azure_insights_connection_string = "mock_connection_string"
+    mock_settings.opentelemetry_connection_string = "mock_connection_string"
     mock_settings.opentelemetry_sqlalchemy_min_query_duration_ms = None
     mocked_exporter = mocker.MagicMock()
     mocked_tracer_provider = mocker.MagicMock()
@@ -43,7 +43,7 @@ def test_setup_telemetry(mocker: MockerFixture):
     setup_telemetry(mock_settings)
 
     mocked_exporter_ctor.assert_called_once_with(
-        connection_string=mock_settings.azure_insights_connection_string,
+        connection_string=mock_settings.opentelemetry_connection_string,
     )
     mocked_batch_span_processor_ctor.assert_called_once_with(mocked_exporter)
     mocked_tracer_provider_ctor.assert_called_once()
@@ -99,7 +99,7 @@ def test_setup_telemetry_disabled(mocker: MockerFixture):
 def test_setup_fastapi_instrumentor(mocker: MockerFixture):
     mock_settings = mocker.MagicMock()
     mock_settings.opentelemetry_exporter = "azure_app_insights"
-    mock_settings.azure_insights_connection_string = "mock_connection_string"
+    mock_settings.opentelemetry_connection_string = "mock_connection_string"
     mocked_instrument_app = mocker.patch(
         "app.telemetry.FastAPIInstrumentor.instrument_app",
     )
@@ -126,7 +126,7 @@ def test_setup_fastapi_instrumentor_disabled(mocker: MockerFixture):
 def test_setup_sqlalchemy_instrumentor(mocker: MockerFixture):
     mock_settings = mocker.MagicMock()
     mock_settings.opentelemetry_exporter = "azure_app_insights"
-    mock_settings.azure_insights_connection_string = "mock_connection_string"
+    mock_settings.opentelemetry_connection_string = "mock_connection_string"
     mocked_instrument_sqlalchemy = mocker.MagicMock()
     mocker.patch(
         "app.telemetry.SQLAlchemyInstrumentor",

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -9,7 +9,9 @@ from app.telemetry import (
 
 def test_setup_telemetry(mocker: MockerFixture):
     mock_settings = mocker.MagicMock()
+    mock_settings.opentelemetry_exporter = "azure_app_insights"
     mock_settings.azure_insights_connection_string = "mock_connection_string"
+    mock_settings.opentelemetry_sqlalchemy_min_query_duration_ms = None
     mocked_exporter = mocker.MagicMock()
     mocked_tracer_provider = mocker.MagicMock()
     mocked_set_tracer_provider = mocker.patch(
@@ -55,7 +57,7 @@ def test_setup_telemetry(mocker: MockerFixture):
 
 def test_setup_telemetry_disabled(mocker: MockerFixture):
     mock_settings = mocker.MagicMock()
-    mock_settings.azure_insights_connection_string = None
+    mock_settings.opentelemetry_exporter = None
     mocked_exporter = mocker.MagicMock()
     mocked_tracer_provider = mocker.MagicMock()
     mocked_set_tracer_provider = mocker.patch(
@@ -96,6 +98,7 @@ def test_setup_telemetry_disabled(mocker: MockerFixture):
 
 def test_setup_fastapi_instrumentor(mocker: MockerFixture):
     mock_settings = mocker.MagicMock()
+    mock_settings.opentelemetry_exporter = "azure_app_insights"
     mock_settings.azure_insights_connection_string = "mock_connection_string"
     mocked_instrument_app = mocker.patch(
         "app.telemetry.FastAPIInstrumentor.instrument_app",
@@ -109,7 +112,7 @@ def test_setup_fastapi_instrumentor(mocker: MockerFixture):
 
 def test_setup_fastapi_instrumentor_disabled(mocker: MockerFixture):
     mock_settings = mocker.MagicMock()
-    mock_settings.azure_insights_connection_string = None
+    mock_settings.opentelemetry_exporter = None
     mocked_instrument_app = mocker.patch(
         "app.telemetry.FastAPIInstrumentor.instrument_app",
     )
@@ -122,6 +125,7 @@ def test_setup_fastapi_instrumentor_disabled(mocker: MockerFixture):
 
 def test_setup_sqlalchemy_instrumentor(mocker: MockerFixture):
     mock_settings = mocker.MagicMock()
+    mock_settings.opentelemetry_exporter = "azure_app_insights"
     mock_settings.azure_insights_connection_string = "mock_connection_string"
     mocked_instrument_sqlalchemy = mocker.MagicMock()
     mocker.patch(
@@ -140,7 +144,7 @@ def test_setup_sqlalchemy_instrumentor(mocker: MockerFixture):
 
 def test_setup_sqlalchemy_disabled(mocker: MockerFixture):
     mock_settings = mocker.MagicMock()
-    mock_settings.azure_insights_connection_string = None
+    mock_settings.opentelemetry_exporter = None
     mocked_instrument_sqlalchemy = mocker.MagicMock()
     mocker.patch(
         "app.telemetry.SQLAlchemyInstrumentor",


### PR DESCRIPTION
The issue we were having with the last deployment was caused by the changes I made to group SQLAlchemy queries by their transaction. It was working just fine when I was testing it during the initial implementation because I was using docker to run the server and in `docker-compose.yaml` we were starting the fastapi's development server which is running in a single processor and a single asyncio loop. However, with `ffcops serve` that's no longer the case and as a result the transaction spans and the query spans were probably created in separate asyncio loops, thus the context var errors.

Since the whole implementation felt hacky to begin with and we're now filtering out very quick queries, I decided to just remove this grouping -- we can always add it in the future if we need it.

Also changed `docker-compose` to use `ffcops serve` to start the api server :)