### PR TITLE
Using SBOM template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       run: echo ${{ steps.docker_build.outputs.digest }}
 
   dtrack:
-    uses: softwareone-platform/ops-template/.github/workflows/dependencyTrack.yml@main
+    uses: softwareone-platform/ops-template/.github/workflows/dependency-track-python-uv.yml@v1
     with:
       projectName: 'ffc-finops-operations'
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,38 +51,8 @@ jobs:
       run: echo ${{ steps.docker_build.outputs.digest }}
 
   dtrack:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: 'Get the major version'
-        id: get_version
-        run: echo "MAJOR=${GITHUB_REF/refs\/tags\//}" |cut -d"." -f1 >> "$GITHUB_OUTPUT"
-      - name: Install uv and set up its cache
-        uses: astral-sh/setup-uv@v4
-        with:
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
-      - name: Install Python
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: ".python-version"
-      - name: Install the project dependancies
-        run: uv sync
-      - name: Install cyclonedx-bom
-        run: uv tool install cyclonedx-bom
-      - name: Generate SBOM
-        run: uv tool run --from cyclonedx-bom cyclonedx-py environment .venv > sbom.json
-      - name: Upload SBOM
-        uses: DependencyTrack/gh-upload-sbom@v3
-        with:
-          serverHostname: 'dependency-track.s1.team'
-          protocol: 'https'
-          apiKey: ${{ secrets.DEPENDENCYTRACK_APIKEY }}
-          projectName: 'ffc-finops-operations'
-          projectVersion: ${{ steps.get_version.outputs.MAJOR }}
-          bomFilename: "sbom.json"
-          autoCreate: true
+    uses: softwareone-platform/ops-template/.github/workflows/dependencyTrack.yml@main
+    with:
+      projectName: 'ffc-finops-operations'
+    secrets:
+      DEPENDENCYTRACK_APIKEY: ${{ secrets.DEPENDENCYTRACK_APIKEY }}


### PR DESCRIPTION
Replaced the custom implementation of the `dtrack` job with a reusable workflow from `softwareone-platform/ops-template`.
DEPENDENCYTRACK_APIKEY secret is required!